### PR TITLE
Fix prelude number detection

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -3182,7 +3182,7 @@ fn generate_tag_check(deser_func: &mut dyn CodeBlock, ident: &RustIdent, tag: Op
 }
 
 // This is used mostly for when thing are tagged have specific ranges.
-fn generate_wrapper_struct(gen_scope: &mut GenerationScope, types: &IntermediateTypes, type_name: &RustIdent, field_type: &RustType, min_max: Option<(Option<isize>, Option<isize>)>) {
+fn generate_wrapper_struct(gen_scope: &mut GenerationScope, types: &IntermediateTypes, type_name: &RustIdent, field_type: &RustType, min_max: Option<(Option<i128>, Option<i128>)>) {
     if min_max.is_some() {
         assert!(types.can_new_fail(type_name));
     }

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -1342,7 +1342,7 @@ pub enum RustStructType {
     },
     Wrapper{
         wrapped: RustType,
-        min_max: Option<(Option<isize>, Option<isize>)>,
+        min_max: Option<(Option<i128>, Option<i128>)>,
     },
     /// This is a no-op in generation but to prevent lookups of things in the prelude
     /// e.g. `int` from not being resolved while still being able to detect it when
@@ -1401,7 +1401,7 @@ impl RustStruct {
         }
     }
 
-    pub fn new_wrapper(ident: RustIdent, tag: Option<usize>, wrapped_type: RustType, min_max: Option<(Option<isize>, Option<isize>)>) -> Self {
+    pub fn new_wrapper(ident: RustIdent, tag: Option<usize>, wrapped_type: RustType, min_max: Option<(Option<i128>, Option<i128>)>) -> Self {
         Self {
             ident,
             tag,

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -40,4 +40,6 @@ cbor_in_cbor = [foo_bytes, uint_bytes: bytes .cbor uint]
 u8 = uint .size 1
 u16 = uint .le 65535
 u32 = 0..4294967295
+u64 = uint .size 8 ; 8 bytes
 i8 = -128..127
+i64 = int .size 8 ; 8 bytes

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -115,5 +115,7 @@ mod tests {
         assert_eq!(0u16, U16::from(0u16));
         assert_eq!(0u32, U32::from(0u32));
         assert_eq!(0i8, I8::from(0i8));
+        assert_eq!(0u64, U64::from(0u64));
+        assert_eq!(0i64, I64::from(0i64));
     }
 }


### PR DESCRIPTION
This PR fixes two issues with the prelude number detection:
1. It failed on `u64` as u64 is larger than isize (at least on my machine)
2. It failed on `int .size` notation