### PR TITLE
Fix for `Int` when used as key, only gen when needed

### DIFF
--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -253,6 +253,23 @@ impl<'a> IntermediateTypes<'a> {
         self.used_as_key = used_as_key;
     }
 
+    pub fn visit_types<F: FnMut(&RustType)>(&self, f: &mut F) {
+        for rust_struct in self.rust_structs().values() {
+            rust_struct.visit_types(self, f);
+        }
+    }
+
+    pub fn is_referenced(&self, ident: &RustIdent) -> bool {
+        let mut found = false;
+        self.visit_types(&mut |ty| match ty {
+            RustType::Rust(id) => if id == ident {
+                found = true
+            },
+            _ => (),
+        });
+        found
+    }
+
     // see self.plain_groups comments
     pub fn mark_plain_group(&mut self, ident: RustIdent, group: Option<cddl::ast::Group<'a>>) {
         self.plain_groups.insert(ident, group);

--- a/tests/preserve-encodings/input.cddl
+++ b/tests/preserve-encodings/input.cddl
@@ -50,10 +50,10 @@ signed_ints = [
 	i_64: int .size 8,
 	n_64: nint
 	u64_max: 18446744073709551615,
-	; this test assumes i64::BITS == isize::BITS or else the cddl parsing lib would mess up
+	; this test assumes i64::BITS == isize::BITS (i.e. 64-bit programs) or else the cddl parsing lib would mess up
 	; if this test fails on your platform we might need to either remove this part
 	; or make a fix for the cddl library.
 	; The fix would be ideal as even though the true min in CBOR would be -u64::MAX
-	; we can't support since isize::BITS is never > 64 in any normal system and likely never will be
+	; we can't test that since isize::BITS is never > 64 in any normal system and likely never will be
 	i64_min: -9223372036854775808
 ]


### PR DESCRIPTION
When used as a key `Int` requires more traits, which can't be auto-generated when used as a tuple enum. This switches it to a named enum any ignores encoding fields for those traits. This also stops duplicate keys which were possible previously when the encoding differed.

We now only generate `Int` when it is actually referenced within the CDDL definitions being generated.