### PR TITLE
Fix dependency on cddl (commit hash in log was incorrect)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,13 @@
+# IDE
+.idea/
+.vscode/
+
+# tests
 tests/*/export/**
 tests/*/export_wasm/**
+
+# Mac files
+**/.DS_STore
+
+# Rust
 target/**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -116,7 +116,7 @@ checksum = "52b3d8b289b6c7d6d8832c8e2bf151c7677126afa627f51e19a6320aec8237cb"
 [[package]]
 name = "cddl"
 version = "0.9.0"
-source = "git+https://github.com/dcSpark/cddl?branch=fix-group-comments#51bac9d087aeb0c628de9e5893741ea3b3347eef"
+source = "git+https://github.com/dcSpark/cddl?branch=fix-group-comments#8ca5917a4906e2c4a3b13778e5ccddef52dd18c6"
 dependencies = [
  "abnf_to_pest",
  "base16",
@@ -290,9 +290,9 @@ dependencies = [
 
 [[package]]
 name = "crossterm"
-version = "0.23.2"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2102ea4f781910f8a5b98dd061f4c2023f479ce7bb1236330099ceb5a93cf17"
+checksum = "e64e6c0fbe2c17357405f7c758c1ef960fce08bdfb2c03d88d2a18d7e09c4b67"
 dependencies = [
  "bitflags",
  "crossterm_winapi",


### PR DESCRIPTION
Execution failed (exit code 101).
/Users/gostkin/.cargo/bin/cargo metadata --verbose --format-version 1 --all-features
stdout :     Updating git repository `https://github.com/dcSpark/cddl`
error: failed to get `cddl` as a dependency of package `cddl-codegen v0.1.0 (/Users/gostkin/CLionProjects/cddl-codegen)`

Caused by:
  failed to load source for dependency `cddl`

Caused by:
  Unable to update https://github.com/dcSpark/cddl?branch=fix-group-comments#51bac9d0

Caused by:
  object not found - no match for id (51bac9d087aeb0c628de9e5893741ea3b3347eef); class=Odb (9); code=NotFound (-3)

stderr : 
