### PR TITLE
Multi file support + Dependency graph ordering

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -6,8 +6,8 @@ use once_cell::sync::Lazy;
 #[derive(Debug, Parser)]
 #[clap()]
 pub struct Cli {
-    /// Input .cddl file to generate from.
-    #[clap(short, long, parse(from_os_str), value_name = "INPUT_FILE")]
+    /// Input .cddl file to generate from. If this is a directory then it will read all *.cddl files and generate one output for each.
+    #[clap(short, long, parse(from_os_str), value_name = "INPUT_FILE/INPUT_DIR")]
     pub input: std::path::PathBuf,
 
     /// Output directory for the generated code.

--- a/src/dep_graph.rs
+++ b/src/dep_graph.rs
@@ -1,0 +1,110 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use cddl::ast::*;
+
+pub fn topological_rule_order<'a>(rules: &'a Vec<&'a Rule<'a>>) -> Vec<&'a Rule<'a>> {
+    let mut adj_list = BTreeMap::new();
+    for cddl_rule in rules.iter() {
+        let (ident, refs) = find_references(cddl_rule);
+        adj_list.insert(ident.ident, (*cddl_rule, refs));
+    }
+    let mut unvisited = adj_list.iter().map(|(k, _v)| *k).collect::<BTreeSet<&str>>();
+    let mut topo_order = Vec::new();
+    let mut processing: BTreeSet<&'a str> = BTreeSet::new();
+    while let Some(u) = unvisited.iter().next().map(|u| *u) {
+        dfs_visit(&mut topo_order, &mut unvisited, &mut processing, &adj_list, u);
+    }
+    topo_order
+}
+
+fn dfs_visit<'a>(
+    topo_order: &mut Vec<&'a Rule<'a>>,
+    unvisited: &mut BTreeSet<&'a str>,
+    processing: &mut BTreeSet<&'a str>,
+    adj_list: &BTreeMap<&'a str, (&'a cddl::ast::Rule<'a>, Vec<&'a Identifier<'a>>)>,
+    u: &'a str) {
+    processing.insert(u);
+    let (rule, neighbors) = adj_list.get(u).unwrap();
+    for v in neighbors.iter() {
+        if processing.contains(v.ident) {
+            eprintln!("Recursive type: '{}' / '{}' - code will possibly need to be edited by hand to use Box/etc", u, v);
+            continue;
+        }
+        if unvisited.contains(v.ident) {
+            dfs_visit(topo_order, unvisited, processing, adj_list, v.ident);
+        }
+    }
+    processing.remove(u);
+    unvisited.remove(u);
+    topo_order.push(rule);
+}
+
+fn find_references<'a>(cddl_rule: &'a Rule<'a>) -> (&'a Identifier, Vec<&'a Identifier<'a>>) {
+    let mut refs = Vec::new();
+    let ident = match cddl_rule {
+        Rule::Type{ rule, .. } => {
+            rule.value.type_choices.iter().for_each(|tc| find_refs_type1(&mut refs, &tc.type1));
+            &rule.name
+        },
+        Rule::Group{ rule, .. } => {
+            assert_eq!(rule.generic_params, None, "{}: Generics not supported on plain groups", rule.name);
+            match &rule.entry {
+                cddl::ast::GroupEntry::InlineGroup{ group, .. } => find_refs_group(&mut refs, group),
+                x => panic!("Group rule with non-inline group? {:?}", x),
+            }
+            &rule.name
+        },
+    };
+    (ident, refs)
+}
+
+fn find_refs_type1<'a>(refs: &mut Vec<&'a Identifier<'a>>, type1: &'a Type1<'a>) {
+    match &type1.type2 {
+        Type2::Typename{ ident, generic_args, .. } => {
+            refs.push(ident);
+            find_refs_generic_args(refs, generic_args);
+        },
+        Type2::ParenthesizedType{ pt, .. } => pt.type_choices.iter().for_each(|tc| find_refs_type1(refs, &tc.type1)),
+        Type2::Map{ group, .. } => find_refs_group(refs, group),
+        Type2::Array{ group, .. } => find_refs_group(refs, group),
+        Type2::Unwrap{ ident, generic_args, .. } => {
+            refs.push(ident);
+            find_refs_generic_args(refs, generic_args);
+        },
+        Type2::ChoiceFromInlineGroup{ group, .. } => find_refs_group(refs, group),
+        Type2::ChoiceFromGroup{ ident, generic_args, .. } => {
+            refs.push(ident);
+            find_refs_generic_args(refs, generic_args);
+        },
+        Type2::TaggedData{ t, .. } => t.type_choices.iter().for_each(|tc| find_refs_type1(refs, &tc.type1)),
+        _ => (),
+    }
+}
+
+fn find_refs_group<'a>(refs: &mut Vec<&'a Identifier<'a>>, group: &'a Group<'a>) {
+    for group_choice in group.group_choices.iter() {
+        for (group_entry, _) in group_choice.group_entries.iter() {
+            match group_entry {
+                GroupEntry::InlineGroup{ group, .. } => find_refs_group(refs, group),
+                GroupEntry::TypeGroupname{ ge, .. } => {
+                    refs.push(&ge.name);
+                    find_refs_generic_args(refs, &ge.generic_args);
+                },
+                GroupEntry::ValueMemberKey{ ge, .. } => {
+                    ge.entry_type.type_choices.iter().for_each(|tc| find_refs_type1(refs, &tc.type1));
+                    match &ge.member_key {
+                        Some(MemberKey::Type1{ t1, .. }) => find_refs_type1(refs, t1),
+                        Some(MemberKey::NonMemberKey{ .. }) => unimplemented!("Please open a github issue with repro steps"),
+                        _ => (),
+                    }
+                },
+            }
+        }
+    }
+}
+
+fn find_refs_generic_args<'a>(refs: &mut Vec<&'a Identifier<'a>>, generic_arg: &'a Option<GenericArgs<'a>>) {
+    if let Some(arg) = generic_arg {
+        arg.args.iter().for_each(|arg| find_refs_type1(refs, arg.arg.as_ref()));
+    }
+}

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -220,7 +220,7 @@ impl GenerationScope {
                 // also make sure not to generate it if we instead generated a binary wrapper type
                 if *gen_rust_alias {
                     self
-                        .rust(types, ident)
+                        .rust_lib()
                         .raw(&format!("pub type {} = {};", ident, base_type.for_rust_member(false)));
                 }
                 if *gen_wasm_alias {

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -127,10 +127,20 @@ impl<'a> SerializeConfig<'a> {
     }
 }
 
+fn concat_files(paths: Vec<&str>) -> std::io::Result<String> {
+    let mut buf = String::new();
+    for path in paths {
+        buf.push_str(&std::fs::read_to_string(path).map_err(|_| panic!("can't read: {}", path)).unwrap());
+    }
+    Ok(buf)
+}
+
 pub struct GenerationScope {
-    global_scope: codegen::Scope,
+    rust_lib_scope: codegen::Scope,
+    rust_scopes: BTreeMap<String, codegen::Scope>,
     serialize_scope: codegen::Scope,
-    wasm_scope: codegen::Scope,
+    wasm_lib_scope: codegen::Scope,
+    wasm_scopes: BTreeMap<String, codegen::Scope>,
     cbor_encodings_scope: codegen::Scope,
     json_scope: codegen::Scope,
     already_generated: BTreeSet<RustIdent>,
@@ -140,9 +150,11 @@ pub struct GenerationScope {
 impl GenerationScope {
     pub fn new() -> Self {
         Self {
-            global_scope: codegen::Scope::new(),
+            rust_lib_scope: codegen::Scope::new(),
+            rust_scopes: BTreeMap::new(),
             serialize_scope: codegen::Scope::new(),
-            wasm_scope: codegen::Scope::new(),
+            wasm_lib_scope: codegen::Scope::new(),
+            wasm_scopes: BTreeMap::new(),
             cbor_encodings_scope: codegen::Scope::new(),
             json_scope: codegen::Scope::new(),
             already_generated: BTreeSet::new(),
@@ -150,14 +162,65 @@ impl GenerationScope {
         }
     }
 
+    /// Generates, i.e. populates the state, based on `types`.
+    /// this does not create any files, call export() after.
     pub fn generate(&mut self, types: &IntermediateTypes) {
+        // Rust (populate rust_lib() - used for top of file before structs)
+        self.rust_lib().raw("// This library was code-generated using an experimental CDDL to rust tool:\n// https://github.com/dcSpark/cddl-codegen");
+        if CLI_ARGS.preserve_encodings && CLI_ARGS.canonical_form {
+            self.rust_lib().raw("use cbor_event::{self, de::Deserializer, se::Serializer};");
+        } else {
+            self.rust_lib().raw("use cbor_event::{self, de::Deserializer, se::{Serialize, Serializer}};");
+        }
+        self.rust_lib().import("std::io", "{BufRead, Seek, Write}");
+        self.rust_lib().import("prelude", "*");
+        self
+            .rust_lib()
+            .raw("use cbor_event::Type as CBORType;")
+            .raw("use cbor_event::Special as CBORSpecial;")
+            .raw("use serialization::*;")
+            .raw("pub mod prelude;")
+            .raw("pub mod serialization;")
+            .raw("use std::collections::BTreeMap;")
+            .raw("use std::convert::{From, TryFrom};");
+        if CLI_ARGS.preserve_encodings {
+            self
+                .rust_lib()
+                .raw("pub mod ordered_hash_map;")
+                .raw("use ordered_hash_map::OrderedHashMap;")
+                .raw("use cbor_event::{Sz, LenSz, StringLenSz};")
+                .raw("pub mod cbor_encodings;")
+                .raw("use cbor_encodings::*;")
+                .raw("extern crate derivative;")
+                .raw("use derivative::Derivative;");
+                self.cbor_encodings().raw("use super::*;");
+        }
+        self.rust_serialize().import("super", "*");
+        self.rust_serialize().import("std::io", "{Seek, SeekFrom}");
+
+        // Wasm (populate wasm_lib() - used for top of file before structs)
+        if CLI_ARGS.wasm {
+            self.wasm_lib().import("wasm_bindgen::prelude", "*");
+            self
+                .wasm_lib()
+                .raw("use std::collections::BTreeMap;");
+                
+            if CLI_ARGS.preserve_encodings {
+                self
+                    .wasm_lib()
+                    .raw("use core::ordered_hash_map::OrderedHashMap;")
+                    .raw("use core::serialization::{LenEncoding, StringEncoding};");
+            }
+        }
+
+        // Type aliases
         for (alias, (base_type, gen_rust_alias, gen_wasm_alias)) in types.type_aliases() {
             // only generate user-defined ones
             if let AliasIdent::Rust(ident) = alias {
                 // also make sure not to generate it if we instead generated a binary wrapper type
                 if *gen_rust_alias {
                     self
-                        .rust()
+                        .rust(types, ident)
                         .raw(&format!("pub type {} = {};", ident, base_type.for_rust_member(false)));
                 }
                 if *gen_wasm_alias {
@@ -171,7 +234,7 @@ impl GenerationScope {
                             FixedValue::Text(s) => ("String", format!("\"{}\".to_owned()", s)),
                         };
                         self
-                            .wasm()
+                            .wasm(types, ident)
                             .raw("#[wasm_bindgen]")
                             .new_fn(&convert_to_snake_case(&ident.to_string()))
                             .vis("pub")
@@ -179,12 +242,14 @@ impl GenerationScope {
                             .line(val);
                     } else {
                         self
-                            .wasm()
+                            .wasm(types, ident)
                             .raw(&format!("pub type {} = {};", ident, base_type.for_wasm_member()));
                     }
                 }
             }
         }
+
+        // Structs
         let mut wasm_wrappers_generated = BTreeSet::new();
         for (rust_ident, rust_struct) in types.rust_structs() {
             assert_eq!(rust_ident, rust_struct.ident());
@@ -225,7 +290,7 @@ impl GenerationScope {
                         if wasm_wrappers_generated.insert(map_ident.to_string()) {
                             codegen_table_type(self, types, rust_ident, domain.clone(), range.clone(), rust_struct.tag());
                         } else {
-                            self.wasm_scope.raw(&format!("type {} = {};", rust_ident, map_ident));
+                            self.wasm(types, rust_ident).raw(&format!("type {} = {};", rust_ident, map_ident));
                         }
                     }
                     //self
@@ -262,6 +327,8 @@ impl GenerationScope {
                 },
             }
         }
+
+        // JSON export
         if CLI_ARGS.json_schema_export {
             self.json_scope.raw("use cddl_lib_core::*;");
             let mut gen_json_schema = Block::new("macro_rules! gen_json_schema");
@@ -290,22 +357,146 @@ impl GenerationScope {
         }
     }
 
-    pub fn rust(&mut self) -> &mut codegen::Scope {
-        &mut self.global_scope
+    /// Exports all already-generated state to the provided directory.
+    /// Call generate() first to populate the generation state.
+    pub fn export(&mut self) -> std::io::Result<()> {
+        // package.json / scripts
+        let rust_dir = if CLI_ARGS.package_json {
+            if CLI_ARGS.json_schema_export {
+                std::fs::create_dir_all(CLI_ARGS.output.join("scripts"))?;
+                std::fs::copy("static/run-json2ts.js", CLI_ARGS.output.join("scripts/run-json2ts.js"))?;
+                std::fs::copy("static/json-ts-types.js", CLI_ARGS.output.join("scripts/json-ts-types.js"))?;
+                std::fs::copy("static/package_json_schemas.json", CLI_ARGS.output.join("package.json"))?;
+            } else {
+                std::fs::copy("static/package.json", CLI_ARGS.output.join("package.json"))?;
+            }
+            CLI_ARGS.output.join("rust")
+        } else {
+            CLI_ARGS.output.clone()
+        };
+
+        // lib.rs / other files (if input is a directory)
+        std::fs::create_dir_all(rust_dir.join("core/src"))?;
+        let mut rust_lib = self.rust_lib().to_string();
+        for (scope, content) in self.rust_scopes.iter() {
+            if scope == "lib" {
+                rust_lib.push_str(&content.to_string());
+            } else {
+                std::fs::write(rust_dir.join(format!("core/src/{}.rs", scope)), content.to_string())?;
+            }
+        }
+        std::fs::write(rust_dir.join("core/src/lib.rs"), rust_lib)?;
+
+        // serialiation.rs
+        let mut serialize_paths = vec!["static/serialization.rs"];
+        if CLI_ARGS.preserve_encodings {
+            serialize_paths.push("static/serialization_preserve.rs");
+            if CLI_ARGS.canonical_form {
+                serialize_paths.push("static/serialization_preserve_force_canonical.rs");
+            } else {
+                serialize_paths.push("static/serialization_preserve_non_force_canonical.rs");
+                serialize_paths.push("static/serialization_non_force_canonical.rs");
+            }
+        } else {
+            serialize_paths.push("static/serialization_non_preserve.rs");
+            serialize_paths.push("static/serialization_non_force_canonical.rs");
+        }
+        let mut serialize_contents = concat_files(serialize_paths)?;
+        serialize_contents.push_str(&self.rust_serialize().to_string());
+        std::fs::write(rust_dir.join("core/src/serialization.rs"), serialize_contents)?;
+
+        // Cargo.toml
+        let mut rust_cargo_toml = std::fs::read_to_string("static/Cargo_rust.toml")?;
+        if CLI_ARGS.preserve_encodings {
+            rust_cargo_toml.push_str("linked-hash-map = \"0.5.3\"\n");
+            rust_cargo_toml.push_str("derivative = \"2.2.0\"\n");
+        }
+        if CLI_ARGS.json_serde_derives {
+            rust_cargo_toml.push_str("serde = { version = \"1.0\", features = [\"derive\"] }\n");
+            rust_cargo_toml.push_str("serde_json = \"1.0.57\"\n");
+        }
+        if CLI_ARGS.json_schema_export {
+            rust_cargo_toml.push_str("schemars = \"0.8.8\"\n");
+        }
+        std::fs::write(rust_dir.join("core/Cargo.toml"), rust_cargo_toml)?;
+
+        // prelude.rs
+        std::fs::copy("static/prelude.rs", rust_dir.join("core/src/prelude.rs"))?;
+
+        // cbor_encodings.rs + ordered_hash_map.rs
+        if CLI_ARGS.preserve_encodings {
+            std::fs::write(rust_dir.join("core/src/cbor_encodings.rs"), self.cbor_encodings().to_string())?;
+            let mut ordered_hash_map_rs = std::fs::read_to_string("static/ordered_hash_map.rs")?;
+            if CLI_ARGS.json_serde_derives {
+                ordered_hash_map_rs.push_str(&std::fs::read_to_string("static/ordered_hash_map_json.rs")?);
+            }
+            if CLI_ARGS.json_schema_export {
+                ordered_hash_map_rs.push_str(&std::fs::read_to_string("static/ordered_hash_map_schemars.rs")?);
+            }
+            std::fs::write(rust_dir.join("core/src/ordered_hash_map.rs"), ordered_hash_map_rs)?;
+        }
+
+        // wasm crate
+        if CLI_ARGS.wasm {
+            std::fs::create_dir_all(rust_dir.join("wasm/src"))?;
+            std::fs::write(rust_dir.join("wasm/src/lib.rs"), self.wasm_lib().to_string())?;
+            let mut wasm_toml = std::fs::read_to_string("static/Cargo_wasm.toml")?;
+            if CLI_ARGS.json_serde_derives {
+                wasm_toml.push_str("serde_json = \"1.0.57\"\n");
+            }
+            std::fs::write(rust_dir.join("wasm/Cargo.toml"), wasm_toml)?;
+        }
+
+        // json-gen crate for exporting JSON schemas
+        if CLI_ARGS.json_schema_export {
+            std::fs::create_dir_all(rust_dir.join("json-gen/src"))?;
+            std::fs::copy("static/Cargo_json_gen.toml", rust_dir.join("json-gen/Cargo.toml"))?;
+            std::fs::write(rust_dir.join("json-gen/src/main.rs"), self.json().to_string())?;
+        }
+
+        Ok(())
     }
 
+    /// Generates in the appropriate scope for `ident`
+    /// Used for all the generated structs and associated traits (besides serialization ones)
+    pub fn rust(&mut self, types: &IntermediateTypes, ident: &RustIdent) -> &mut codegen::Scope {
+        let scope_name = types.scope(ident).to_owned();
+        self.rust_scopes.entry(scope_name).or_insert(codegen::Scope::new())
+    }
+
+    /// Scope header above the rest of the "lib" rust scope.
+    /// This is useful for when there is no explicit scope
+    /// e.g. implicit types like arrays/tables (for WASM)
+    pub fn rust_lib(&mut self) -> &mut codegen::Scope {
+        &mut self.rust_lib_scope
+    }
+
+    /// We dump all serialization into a "serialization" scope as these details
+    /// aren't very helpful to users as long as they work so we don't clutter other files.
     pub fn rust_serialize(&mut self) -> &mut codegen::Scope {
         &mut self.serialize_scope
     }
 
-    pub fn wasm(&mut self) -> &mut codegen::Scope {
-        &mut self.wasm_scope
+    /// Generates in the appropriate scope for `ident`
+    /// Used for all the generated WASM wrapper structs and associated traits
+    pub fn wasm(&mut self, types: &IntermediateTypes, ident: &RustIdent) -> &mut codegen::Scope {
+        let scope_name = types.scope(ident).to_owned();
+        self.wasm_scopes.entry(scope_name).or_insert(codegen::Scope::new())
     }
 
+    /// Scope header above the rest of the "lib" WASM scope.
+    /// This is useful for when there is no explicit scope
+    /// e.g. implicit types like arrays/tables (for WASM)
+    pub fn wasm_lib(&mut self) -> &mut codegen::Scope {
+        &mut self.wasm_lib_scope
+    }
+
+    /// If used, all associated *Encoding structs.
     pub fn cbor_encodings(&mut self) -> &mut codegen::Scope {
         &mut self.cbor_encodings_scope
     }
 
+    /// If used, scope for json-gen crate's main.rs
     pub fn json(&mut self) -> &mut codegen::Scope {
         &mut self.json_scope
     }
@@ -1102,9 +1293,11 @@ impl GenerationScope {
             None => true,
         };
         if repeat {
-            self.global_scope = codegen::Scope::new();
+            self.rust_scopes.clear();
+            self.rust_lib_scope = codegen::Scope::new();
             self.serialize_scope = codegen::Scope::new();
-            self.wasm_scope = codegen::Scope::new();
+            self.wasm_scopes.clear();
+            self.wasm_lib_scope = codegen::Scope::new();
             self.cbor_encodings_scope = codegen::Scope::new();
             self.json_scope = codegen::Scope::new();
             self.already_generated.clear();
@@ -1162,7 +1355,7 @@ impl GenerationScope {
                 wrapper.s_impl.push_fn(new_func);
             }
             add_wasm_enum_getters(&mut wrapper.s_impl, name, &variants, None);
-            wrapper.push(self);
+            wrapper.push(self, types);
             //push_wasm_wrapper(self, name, s, s_impl);
         }
     }
@@ -1221,7 +1414,7 @@ impl GenerationScope {
                 .ret(inner_type)
                 .line("self.0");
             self
-                .wasm()
+                .wasm_lib()
                 .raw("#[wasm_bindgen]")
                 .push_struct(s)
                 .raw("#[wasm_bindgen]")
@@ -1403,7 +1596,8 @@ fn create_base_rust_struct<'a>(types: &IntermediateTypes<'a>, ident: &RustIdent)
     (s, group_impl)
 }
 
-struct WasmWrapper {
+struct WasmWrapper<'a> {
+    ident: &'a RustIdent,
     s: codegen::Struct,
     s_impl: codegen::Impl,
     // rust -> wasm
@@ -1412,24 +1606,24 @@ struct WasmWrapper {
     from_native: Option<codegen::Impl>,
 }
 
-impl WasmWrapper {
-    fn push(self, gen_scope: &mut GenerationScope) {
+impl<'a> WasmWrapper<'a> {
+    fn push(self, gen_scope: &mut GenerationScope, types: &IntermediateTypes) {
         gen_scope
-            .wasm()
+            .wasm(types, self.ident)
             .raw("#[wasm_bindgen]")
             .push_struct(self.s)
             .raw("#[wasm_bindgen]")
             .push_impl(self.s_impl);
         if let Some(from_wasm) = self.from_wasm {
-            gen_scope.wasm().push_impl(from_wasm);
+            gen_scope.wasm(types, self.ident).push_impl(from_wasm);
         }
         if let Some(from_native) = self.from_native {
-            gen_scope.wasm().push_impl(from_native);
+            gen_scope.wasm(types, self.ident).push_impl(from_native);
         }
     }
 }
 
-fn create_base_wasm_struct(gen_scope: &GenerationScope, ident: &RustIdent, exists_in_rust: bool) -> WasmWrapper {
+fn create_base_wasm_struct<'a>(gen_scope: &GenerationScope, ident: &'a RustIdent, exists_in_rust: bool) -> WasmWrapper<'a> {
     let name = &ident.to_string();
     let mut s = codegen::Struct::new(name);
     s
@@ -1493,6 +1687,7 @@ fn create_base_wasm_struct(gen_scope: &GenerationScope, ident: &RustIdent, exist
         }
     }
     WasmWrapper {
+        ident,
         s,
         s_impl,
         from_wasm: None,
@@ -1502,7 +1697,7 @@ fn create_base_wasm_struct(gen_scope: &GenerationScope, ident: &RustIdent, exist
 
 /// default_structure will have it be a DIRECT wrapper with a tuple field of core::{ident}
 /// this will include generating to/from traits automatically
-fn create_base_wasm_wrapper(gen_scope: &GenerationScope, ident: &RustIdent, default_structure: bool) -> WasmWrapper {
+fn create_base_wasm_wrapper<'a>(gen_scope: &GenerationScope, ident: &'a RustIdent, default_structure: bool) -> WasmWrapper<'a> {
     assert!(CLI_ARGS.wasm);
     let mut base = create_base_wasm_struct(gen_scope, ident, true);
     let name = &ident.to_string();
@@ -1747,14 +1942,17 @@ fn create_deserialize_impls(ident: &RustIdent, rep: Option<Representation>, tag:
 
 fn push_rust_struct(
     gen_scope: &mut GenerationScope,
+    types: &IntermediateTypes,
     name: &RustIdent,
     s: codegen::Struct,
     s_impl: codegen::Impl,
     ser_impl: codegen::Impl,
     ser_embedded_impl: Option<codegen::Impl>,
 ) {
-    gen_scope.rust().push_struct(s);
-    gen_scope.rust().push_impl(s_impl);
+    gen_scope
+        .rust(types, name)
+        .push_struct(s)
+        .push_impl(s_impl);
     gen_scope.rust_serialize().push_impl(ser_impl);
     if let Some(s) = ser_embedded_impl {
         gen_scope.rust_serialize().push_impl(s);
@@ -1889,9 +2087,9 @@ fn codegen_table_type(gen_scope: &mut GenerationScope, types: &IntermediateTypes
         .arg_self()
         .ret(inner_type)
         .line("self.0");
-    wrapper.push(gen_scope);
+    wrapper.push(gen_scope, types);
     gen_scope
-        .wasm()
+        .wasm_lib()
         .push_impl(from_wasm)
         .push_impl(to_wasm);
 }
@@ -2125,7 +2323,7 @@ fn codegen_struct(gen_scope: &mut GenerationScope, types: &IntermediateTypes, na
         }
         wasm_new.line(format!("Self(core::{}::new({}))", name, wasm_new_args.join(", ")));
         wrapper.s_impl.push_fn(wasm_new);
-        wrapper.push(gen_scope);
+        wrapper.push(gen_scope, types);
     }
     
     // Rust-only for the rest of this function
@@ -2682,7 +2880,7 @@ fn codegen_struct(gen_scope: &mut GenerationScope, types: &IntermediateTypes, na
             deser_impl.push_fn(deser_f);
         },
     };
-    push_rust_struct(gen_scope, name, native_struct, native_impl, ser_impl, ser_embedded_impl);
+    push_rust_struct(gen_scope, types, name, native_struct, native_impl, ser_impl, ser_embedded_impl);
     // TODO: generic deserialize (might need backtracking)
     if gen_scope.deserialize_generated(name) {
         gen_scope.rust_serialize().push_impl(deser_impl);
@@ -2771,7 +2969,7 @@ fn codegen_group_choices(gen_scope: &mut GenerationScope, types: &IntermediateTy
         // enum-getters
         add_wasm_enum_getters(&mut wrapper.s_impl, name, &variants, Some(rep));
         //push_wasm_wrapper(gen_scope, name, s, s_impl);
-        wrapper.push(gen_scope);
+        wrapper.push(gen_scope, types);
     }
 }
 
@@ -2967,7 +3165,7 @@ fn generate_enum(gen_scope: &mut GenerationScope, types: &IntermediateTypes, nam
             kind.new_variant(&variant.name.to_string());
         }
         gen_scope
-            .wasm()
+            .wasm(types, name)
             .raw("#[wasm_bindgen]")
             .push_enum(kind);
     }
@@ -3211,7 +3409,7 @@ fn generate_enum(gen_scope: &mut GenerationScope, types: &IntermediateTypes, nam
     // TODO: should we stick this in another scope somewhere or not? it's not exposed to wasm
     // however, clients expanding upon the generated lib might find it of use to change.
     gen_scope
-        .rust()
+        .rust(types, name)
         .push_enum(e)
         .push_impl(e_impl);
     gen_scope
@@ -3307,7 +3505,7 @@ fn generate_wrapper_struct(gen_scope: &mut GenerationScope, types: &Intermediate
             get.line(field_type.to_wasm_boundary("self.0.get()", false));
         }
         wrapper.s_impl.push_fn(get);
-        wrapper.push(gen_scope);
+        wrapper.push(gen_scope, types);
     }
 
     // TODO: do we want to get rid of the rust struct and embed the tag / min/max size here?
@@ -3545,7 +3743,7 @@ fn generate_wrapper_struct(gen_scope: &mut GenerationScope, types: &Intermediate
         .ret("Self")
         .line(format!("wrapper.{}", inner_var));
     gen_scope
-        .rust()
+        .rust(types, type_name)
         .push_struct(s)
         .push_impl(s_impl)
         .push_impl(from_impl)
@@ -3640,7 +3838,7 @@ fn generate_int(gen_scope: &mut GenerationScope, types: &IntermediateTypes) {
             .push_fn(wasm_new)
             .push_fn(to_str)
             .push_fn(from_str);
-        wrapper.push(gen_scope);
+        wrapper.push(gen_scope, types);
     }
 
     let mut native_struct = codegen::Enum::new("Int");
@@ -3795,7 +3993,7 @@ fn generate_int(gen_scope: &mut GenerationScope, types: &IntermediateTypes) {
         .push_block(try_from_else);
 
     gen_scope
-        .rust()
+        .rust_lib()
         .push_enum(native_struct)
         .push_enum(int_err)
         .push_impl(native_impl)

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -382,7 +382,7 @@ impl<'a> IntermediateTypes<'a> {
             let def = format!("prelude_{} = {}\n", cddl_name, cddl_prelude(&cddl_name).unwrap());
             let cddl = cddl::parser::cddl_from_str(&def, true).unwrap();
             assert_eq!(cddl.rules.len(), 1);
-            crate::parsing::parse_rule(self, cddl.rules.first().unwrap(), "prelude".to_owned());
+            crate::parsing::parse_rule(self, cddl.rules.first().unwrap());
         }
     }
 }

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -31,6 +31,7 @@ pub struct IntermediateTypes<'a> {
     generic_instances: BTreeMap<RustIdent, GenericInstance>,
     news_can_fail: BTreeSet<RustIdent>,
     used_as_key: BTreeSet<RustIdent>,
+    scopes: BTreeMap<RustIdent, String>,
 }
 
 impl<'a> IntermediateTypes<'a> {
@@ -46,6 +47,7 @@ impl<'a> IntermediateTypes<'a> {
             generic_instances: BTreeMap::new(),
             news_can_fail: BTreeSet::new(),
             used_as_key: BTreeSet::new(),
+            scopes: BTreeMap::new(),
         }
     }
 
@@ -317,6 +319,18 @@ impl<'a> IntermediateTypes<'a> {
         self.news_can_fail.contains(name)
     }
 
+    pub fn mark_scope(&mut self, ident: RustIdent, scope: String) {
+        if let Some(old_scope) = self.scopes.insert(ident.clone(), scope.clone()) {
+            if old_scope != scope {
+                panic!("{} defined multiple times, first referenced in scope '{}' then in '{}'", ident, old_scope, scope);
+            }
+        }
+    }
+
+    pub fn scope(&self, ident: &RustIdent) -> &str {
+        self.scopes.get(ident).unwrap()
+    }
+
     pub fn used_as_key(&self, name: &RustIdent) -> bool {
         self.used_as_key.contains(name)
     }
@@ -368,7 +382,7 @@ impl<'a> IntermediateTypes<'a> {
             let def = format!("prelude_{} = {}\n", cddl_name, cddl_prelude(&cddl_name).unwrap());
             let cddl = cddl::parser::cddl_from_str(&def, true).unwrap();
             assert_eq!(cddl.rules.len(), 1);
-            crate::parsing::parse_rule(self, cddl.rules.first().unwrap());
+            crate::parsing::parse_rule(self, cddl.rules.first().unwrap(), "prelude".to_owned());
         }
     }
 }

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -328,7 +328,7 @@ impl<'a> IntermediateTypes<'a> {
     }
 
     pub fn scope(&self, ident: &RustIdent) -> &str {
-        self.scopes.get(ident).unwrap()
+        self.scopes.get(ident).map(|s| s.as_str()).unwrap_or("lib")
     }
 
     pub fn used_as_key(&self, name: &RustIdent) -> bool {

--- a/src/main.rs
+++ b/src/main.rs
@@ -86,7 +86,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }).collect::<Vec<_>>();
     // We need to know beforehand which are plain groups so we can serialize them properly
-    // ie x = (3, 4), y = [1, x, 2] would be [1, 3, 4, 2] instead of [1, [3, 4], 2]
+    // e.g. x = (3, 4), y = [1, x, 2] should be [1, 3, 4, 2] instead of [1, [3, 4], 2]
     for cddl_rule in cddl_rules.iter() {
         if let cddl::ast::Rule::Group{ rule, .. } = cddl_rule {
             // Freely defined group - no need to generate anything outside of group module
@@ -101,14 +101,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Creating intermediate form from the CDDL
     for cddl_rule in dep_graph::topological_rule_order(&cddl_rules) {
-        // We inserted string constants with specific prefixes earlier to mark scope
-        if let Some(new_scope) = rule_is_scope_marker(cddl_rule) {
-            println!("Switching from scope '{}' to '{}'", scope, new_scope);
-            scope = new_scope;
-        } else {
-            println!("\n\n------------------------------------------\n- Handling rule: {}\n------------------------------------", scope);
-            parse_rule(&mut types, cddl_rule);
-        }
+        println!("\n\n------------------------------------------\n- Handling rule: {}\n------------------------------------", scope);
+        parse_rule(&mut types, cddl_rule);
     }
     types.finalize();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 pub (crate) mod cli;
+pub (crate) mod dep_graph;
 pub (crate) mod generation;
 pub (crate) mod intermediate;
 pub (crate) mod parsing;
@@ -15,7 +16,11 @@ use intermediate::{
     IntermediateTypes,
     RustIdent,
 };
-use parsing::{parse_rule, rule_is_scope_marker};
+use parsing::{
+    parse_rule,
+    rule_ident,
+    rule_is_scope_marker
+};
 
 use cli::CLI_ARGS;
 
@@ -34,6 +39,7 @@ fn cddl_paths(output: &mut Vec<std::path::PathBuf>, cd: &std::path::PathBuf) -> 
 }
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Pre-processing files for multi-file support
     let input_files = if CLI_ARGS.input.is_dir() {
         let mut cddl_paths_buf = Vec::new();
         cddl_paths(&mut cddl_paths_buf, &CLI_ARGS.input)?;
@@ -41,7 +47,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     } else {
         vec![CLI_ARGS.input.clone()]
     };
-
     // To get around an issue with cddl where you can't parse a partial cddl fragment
     // we must group all files together. To mark scope we insert string constants with
     // a specific, unlikely to ever be used, prefix. The names contain a number after
@@ -60,22 +65,29 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 "lib"
             };
             std::fs::read_to_string(input_file)
-                .map(|raw| format!("\n_CDDL_CODEGEN_SCOPE_MARKER_{}_ = \"{}\"\n{}\n", i, scope, raw))
+                .map(|raw| format!("\n{}{} = \"{}\"\n{}\n", parsing::SCOPE_MARKER, i, scope, raw))
         }).collect::<Result<String, _>>()?;
+
+    // Plain group / scope marking
     let cddl = cddl::parser::cddl_from_str(&input_files_content, true)?;
-    // println!("{:#?}", cddl);
     let mut types = IntermediateTypes::new();
-    let mut gen_scope = GenerationScope::new();
-    // TODO: this is a quick hack to get around out-of-order declarations in the cddl file
-    // e.g. foo = [bar], bar = ... where bar can't deserialize would still generate foo's deserialize
-    // if we just do everything independently and it's our of order, so as a super quick fix just do multiple
-    // passes until the number of unsupported structs doesn't change.
-    // We should probably construct some dependency graph instead of doing this.
-    let mut not_deserialized = None;
-    let mut pass_count = 0;
-    // Need to know beforehand which are plain groups so we can serialize them properly
+    // mark scope and filter scope markers
+    let mut scope = "lib".to_owned();
+    let cddl_rules = cddl.rules.iter().filter(|cddl_rule| {
+        // We inserted string constants with specific prefixes earlier to mark scope
+        if let Some(new_scope) = rule_is_scope_marker(*cddl_rule) {
+            println!("Switching from scope '{}' to '{}'", scope, new_scope);
+            scope = new_scope;
+            false
+        } else {
+            let ident = rule_ident(cddl_rule);
+            types.mark_scope(ident, scope.clone());
+            true
+        }
+    }).collect::<Vec<_>>();
+    // We need to know beforehand which are plain groups so we can serialize them properly
     // ie x = (3, 4), y = [1, x, 2] would be [1, 3, 4, 2] instead of [1, [3, 4], 2]
-    for cddl_rule in cddl.rules.iter() {
+    for cddl_rule in cddl_rules.iter() {
         if let cddl::ast::Rule::Group{ rule, .. } = cddl_rule {
             // Freely defined group - no need to generate anything outside of group module
             match &rule.entry {
@@ -86,34 +98,25 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
     }
-    let mut scope = "lib".to_owned();
-    // TODO: handle out-of-order definition properly instead of just mandating at least two passes.
-    // If we separate codegen and parsing this would probably be a lot easier too.
-    // This is probably hiding some other issues too.
-    while pass_count < 2 || gen_scope.reset_except_not_deserialized(&mut not_deserialized) {
-        println!("Pass #{}", pass_count);
-        pass_count += 1;
-        // Can't generate groups of imports with codegen::Import so we just output this as raw text
-        // since we don't need it to be dynamic so it's fine. codegen::Impl::new("a", "{z::b, z::c}")
-        // does not work.
 
-        for cddl_rule in cddl.rules.iter() {
-            // We inserted string constants with specific prefixes earlier to mark scope
-            if let Some(new_scope) = rule_is_scope_marker(cddl_rule) {
-                println!("Switching from scope '{}' to '{}'", scope, new_scope);
-                scope = new_scope;
-            } else {
-                println!("\n\n------------------------------------------\n- Handling rule: {}\n------------------------------------", cddl_rule.name());
-                parse_rule(&mut types, cddl_rule, scope.clone());
-            }
+    // Creating intermediate form from the CDDL
+    for cddl_rule in dep_graph::topological_rule_order(&cddl_rules) {
+        // We inserted string constants with specific prefixes earlier to mark scope
+        if let Some(new_scope) = rule_is_scope_marker(cddl_rule) {
+            println!("Switching from scope '{}' to '{}'", scope, new_scope);
+            scope = new_scope;
+        } else {
+            println!("\n\n------------------------------------------\n- Handling rule: {}\n------------------------------------", scope);
+            parse_rule(&mut types, cddl_rule);
         }
-        types.finalize();
-        println!("\n-----------------------------------------\n- Generating code...\n------------------------------------");
-        gen_scope.generate(&types);
     }
+    types.finalize();
 
+    // Generating code from intermediate form
+    println!("\n-----------------------------------------\n- Generating code...\n------------------------------------");
+    let mut gen_scope = GenerationScope::new();
+    gen_scope.generate(&types);
     gen_scope.export()?;
-
     types.print_info();
 
     gen_scope.print_structs_without_deserialize();

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -38,6 +38,23 @@ struct Type2AndParent<'a> {
     parent: &'a Type1<'a>,
 }
 
+/// Some means it is a scope marker, containing the scope
+pub fn rule_is_scope_marker(cddl_rule: &cddl::ast::Rule) -> Option<String> {
+    match cddl_rule {
+        Rule::Type{ rule: TypeRule{ name: Identifier{ ident , .. }, value, .. }, .. } => {
+            if value.type_choices.len() == 1 && ident.starts_with("_CDDL_CODEGEN_SCOPE_MARKER_") {
+                match &value.type_choices[0].type1.type2 {
+                    Type2::TextValue{ value, .. } => Some(value.to_string()),
+                    _ => None,
+                }
+            } else {
+                None
+            }
+        },
+        _ => None,
+    }
+}
+
 pub fn parse_rule(types: &mut IntermediateTypes, cddl_rule: &cddl::ast::Rule, scope: String) {
     let rust_ident = match cddl_rule {
         cddl::ast::Rule::Type{ rule, .. } => {


### PR DESCRIPTION
For generating larger projects it may be desirable to generate into different files. Now --input can take a directory. If it is given a directory it will read all .cddl files and generate each in its own .rs file for export. Serialization/*Encodings are still all in one file. This resolves #95 

Also includes dependency graph ordering that fixes #93 and is essential for multi file support where the cyclic references are across file boundaries. This should also fix #98 