### PR TITLE
Add @name annotation support for typechoice variants

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -672,6 +672,7 @@ impl GenerationScope {
         let mut rust_lib = self.rust_lib().to_string();
         for (scope, content) in self.rust_scopes.iter_mut() {
             if scope == "lib" {
+                rust_lib.push_str("\n\n");
                 rust_lib.push_str(&content.to_string());
             } else {
                 content.raw("use super::*;");
@@ -747,6 +748,7 @@ impl GenerationScope {
             let mut wasm_lib = self.wasm_lib().to_string();
             for (scope, content) in self.wasm_scopes.iter_mut() {
                 if scope == "lib" {
+                    wasm_lib.push_str("\n\n");
                     wasm_lib.push_str(&content.to_string());
                 } else {
                     content.raw("use super::*;");

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -447,7 +447,11 @@ pub fn create_variants_from_type_choices(types: &mut IntermediateTypes, parent_v
     let mut variant_names_used = BTreeMap::<String, u32>::new();
     type_choices.iter().map(|choice| {
         let rust_type = rust_type_from_type1(types, parent_visitor, &choice.type1);
-        let variant_name = append_number_if_duplicate(&mut variant_names_used, rust_type.for_variant().to_string());
+        let base_name = match RuleMetadata::from(choice.type1.comments_after_type.as_ref()) {
+            RuleMetadata { name: Some(name), .. } => convert_to_camel_case(&name),
+            _ => rust_type.for_variant().to_string(),
+        };
+        let variant_name = append_number_if_duplicate(&mut variant_names_used, base_name);
         EnumVariant::new(VariantIdent::new_custom(variant_name), rust_type, false)
     }).collect()
 }

--- a/tests/comment-dsl/input.cddl
+++ b/tests/comment-dsl/input.cddl
@@ -22,3 +22,8 @@ typechoice =
     [1, bytes] ; @name case_2
 
 protocol_magic = uint ; @newtype
+
+typechoice_variants =
+    text      ; @name case_1
+    /
+    [* text]  ; @name case_2

--- a/tests/comment-dsl/tests.rs
+++ b/tests/comment-dsl/tests.rs
@@ -53,6 +53,14 @@ mod tests {
     }
 
     #[test]
+    fn type_choice_variants() {
+        // just checking these fields exist with the expected name
+        TypechoiceVariants::new_case1("".to_string());
+        TypechoiceVariants::new_case2(vec!["".to_string()]);
+        assert!(true);
+    }
+
+    #[test]
     fn newtype() {
         let pm = ProtocolMagic::new(5);
         assert_eq!(pm.get(), 5);


### PR DESCRIPTION
I accidentally missed support for `@name` annotations for typechoices with multiple variants. This PR fixes it

At the same time, I also fixes some issue with missing newlines in the outputted code