### PR TITLE
Remove unnecessary WASM aliases

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -545,82 +545,96 @@ impl GenerationScope {
         }
 
         // Structs
-        let mut wasm_wrappers_generated = BTreeSet::new();
-        for (rust_ident, rust_struct) in types.rust_structs() {
-            assert_eq!(rust_ident, rust_struct.ident());
-            if CLI_ARGS.wasm {
-                rust_struct.visit_types(types, &mut |ty| {
-                    match ty {
-                        ConceptualRustType::Array(elem) => {
-                            if !ty.directly_wasm_exposable() {
-                                let array_ident = elem.name_as_wasm_array();
-                                if wasm_wrappers_generated.insert(array_ident.clone()) {
-                                    self.generate_array_type(types, *elem.clone(), &RustIdent::new(CDDLIdent::new(array_ident)));
+        {
+            // we can ignore types already handled by the alias
+            // otherwise wasm_wrappers_generated may cause us to pointlessly create aliases to aliases
+            let mut existing_aliases = types.type_aliases().iter().fold(BTreeSet::<RustIdent>::new(), |mut acc, (alias, _)| {
+                match alias {
+                    AliasIdent::Reserved(_) => {},
+                    AliasIdent::Rust(ident) => { acc.insert(ident.clone()); }
+                };
+                acc
+            });
+
+            let mut wasm_wrappers_generated = BTreeSet::new();
+            for (rust_ident, rust_struct) in types.rust_structs() {
+                assert_eq!(rust_ident, rust_struct.ident());
+                if CLI_ARGS.wasm {
+                    rust_struct.visit_types_excluding(types, &mut |ty| {
+                        match ty {
+                            ConceptualRustType::Array(elem) => {
+                                if !ty.directly_wasm_exposable() {
+                                    let array_ident = elem.name_as_wasm_array();
+                                    if wasm_wrappers_generated.insert(array_ident.clone()) {
+                                        self.generate_array_type(types, *elem.clone(), &RustIdent::new(CDDLIdent::new(array_ident)));
+                                    }
                                 }
-                            }
-                        },
-                        ConceptualRustType::Map(k, v) => {
-                            let map_ident = ConceptualRustType::name_for_wasm_map(&k, &v);
-                            if wasm_wrappers_generated.insert(map_ident.to_string()) {
-                                codegen_table_type(self, types, &map_ident, *k.clone(), *v.clone(), None);
-                            }
-                            if !ConceptualRustType::Array(Box::new(*k.clone())).directly_wasm_exposable() {
-                                let keys_ident = k.name_as_wasm_array();
-                                if wasm_wrappers_generated.insert(keys_ident.clone()) {
-                                    self.generate_array_type(types, *k.clone(), &RustIdent::new(CDDLIdent::new(keys_ident)));
+                            },
+                            ConceptualRustType::Map(k, v) => {
+                                let map_ident = ConceptualRustType::name_for_wasm_map(&k, &v);
+                                if wasm_wrappers_generated.insert(map_ident.to_string()) {
+                                    codegen_table_type(self, types, &map_ident, *k.clone(), *v.clone(), None, false);
                                 }
-                            }
-                        },
-                        _ => (),
-                    }
-                });
-            }
-            match rust_struct.variant() {
-                RustStructType::Record(record) => {
-                    codegen_struct(self, types, rust_ident, rust_struct.tag(), record);
-                },
-                RustStructType::Table { domain, range } => {
-                    if CLI_ARGS.wasm {
-                        let map_ident = ConceptualRustType::name_for_wasm_map(domain, range);
-                        if wasm_wrappers_generated.insert(map_ident.to_string()) {
-                            codegen_table_type(self, types, rust_ident, domain.clone(), range.clone(), rust_struct.tag());
-                        } else {
-                            self.wasm(types, rust_ident)
-                                .push_type_alias(TypeAlias::new(rust_ident, map_ident));
+                                if !ConceptualRustType::Array(Box::new(*k.clone())).directly_wasm_exposable() {
+                                    let keys_ident = k.name_as_wasm_array();
+                                    if wasm_wrappers_generated.insert(keys_ident.clone()) {
+                                        self.generate_array_type(types, *k.clone(), &RustIdent::new(CDDLIdent::new(keys_ident)));
+                                    }
+                                }
+                            },
+                            _ => (),
                         }
-                    }
-                    //self
-                    //    .rust()
-                    //    .push_type_alias(TypeAlias::new(rust_struct.ident(), ConceptualRustType::name_for_rust_map(domain, range, false)));
-                },
-                RustStructType::Array { element_type } => {
-                    if CLI_ARGS.wasm {
-                        self.generate_array_type(types, element_type.clone(), rust_ident);
-                    }
-                    //self
-                    //    .rust()
-                    //    .push_type_alias(TypeAlias::new(rust_struct.ident(), element_type.name_as_rust_array(false)));
-                },
-                RustStructType::TypeChoice { variants } => {
-                    self.generate_type_choices_from_variants(types, rust_ident, variants, rust_struct.tag());
-                },
-                RustStructType::GroupChoice { variants, rep } => {
-                    codegen_group_choices(self, types, rust_ident, variants, *rep, rust_struct.tag())
-                },
-                RustStructType::Wrapper{ wrapped, min_max } => {
-                    match rust_struct.tag() {
-                        Some(tag) => generate_wrapper_struct(self, types, rust_ident, &wrapped.clone().tag(tag), min_max.clone()),
-                        None => generate_wrapper_struct(self, types, rust_ident, wrapped, min_max.clone()),
-                    }
-                },
-                RustStructType::Prelude => {
-                    match rust_ident.to_string().as_ref() {
-                        "Int" => if types.is_referenced(rust_ident) {
-                            generate_int(self, types)
-                        },
-                        other => panic!("prelude not defined: {}", other),
-                    }
-                },
+                    }, &mut existing_aliases);
+                }
+                match rust_struct.variant() {
+                    RustStructType::Record(record) => {
+                        codegen_struct(self, types, rust_ident, rust_struct.tag(), record);
+                    },
+                    RustStructType::Table { domain, range } => {
+                        if CLI_ARGS.wasm {
+                            let map_ident = ConceptualRustType::name_for_wasm_map(domain, range);
+                            // want to use `contains` instead of insert
+                            // since although map_ident may not be required for this struct
+                            // we may still have to generate it later if a table of the same shape is embedded inside different struct
+                            if !wasm_wrappers_generated.contains(&map_ident.to_string()) {
+                                codegen_table_type(self, types, rust_ident, domain.clone(), range.clone(), rust_struct.tag(), true);
+                            } else {
+                                self.wasm(types, rust_ident).push_type_alias(TypeAlias::new(rust_ident, map_ident));
+                            }
+                        }
+                        //self
+                        //    .rust()
+                        //    .push_type_alias(TypeAlias::new(rust_struct.ident(), ConceptualRustType::name_for_rust_map(domain, range, false)));
+                    },
+                    RustStructType::Array { element_type } => {
+                        if CLI_ARGS.wasm {
+                            self.generate_array_type(types, element_type.clone(), rust_ident);
+                        }
+                        //self
+                        //    .rust()
+                        //    .push_type_alias(TypeAlias::new(rust_struct.ident(), element_type.name_as_rust_array(false)));
+                    },
+                    RustStructType::TypeChoice { variants } => {
+                        self.generate_type_choices_from_variants(types, rust_ident, variants, rust_struct.tag());
+                    },
+                    RustStructType::GroupChoice { variants, rep } => {
+                        codegen_group_choices(self, types, rust_ident, variants, *rep, rust_struct.tag())
+                    },
+                    RustStructType::Wrapper{ wrapped, min_max } => {
+                        match rust_struct.tag() {
+                            Some(tag) => generate_wrapper_struct(self, types, rust_ident, &wrapped.clone().tag(tag), min_max.clone()),
+                            None => generate_wrapper_struct(self, types, rust_ident, wrapped, min_max.clone()),
+                        }
+                    },
+                    RustStructType::Prelude => {
+                        match rust_ident.to_string().as_ref() {
+                            "Int" => if types.is_referenced(rust_ident) {
+                                generate_int(self, types)
+                            },
+                            other => panic!("prelude not defined: {}", other),
+                        }
+                    },
+                }
             }
         }
 
@@ -2080,6 +2094,7 @@ fn create_base_rust_struct<'a>(types: &IntermediateTypes<'a>, ident: &RustIdent)
     (s, group_impl)
 }
 
+#[derive(Debug)]
 struct WasmWrapper<'a> {
     ident: &'a RustIdent,
     s: codegen::Struct,
@@ -2460,7 +2475,7 @@ pub fn table_type() -> &'static str {
     }
 }
 
-fn codegen_table_type(gen_scope: &mut GenerationScope, types: &IntermediateTypes, name: &RustIdent, key_type: RustType, value_type: RustType, tag: Option<usize>) {
+fn codegen_table_type(gen_scope: &mut GenerationScope, types: &IntermediateTypes, name: &RustIdent, key_type: RustType, value_type: RustType, tag: Option<usize>, exists_in_rust: bool) {
     assert!(CLI_ARGS.wasm);
     assert!(tag.is_none(), "TODO: why is this not used anymore? is it since it's only on the wasm side now so it shouldn't happen now?");
     // this would interfere with loop code generation unless we
@@ -2469,7 +2484,12 @@ fn codegen_table_type(gen_scope: &mut GenerationScope, types: &IntermediateTypes
     // non-break special value once read
     assert!(!key_type.cbor_types().contains(&CBORType::Special));
     let mut wrapper = create_base_wasm_struct(gen_scope, name, false);
-    let inner_type = ConceptualRustType::name_for_rust_map(&key_type, &value_type, true);
+
+    let inner_type = if exists_in_rust {
+        format!("core::{}", name)
+    } else {
+        ConceptualRustType::name_for_rust_map(&key_type, &value_type, true)
+    };
     wrapper.s.tuple_field(Some("pub(crate)".to_string()), &inner_type);
     // new
     let mut new_func = codegen::Function::new("new");

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -1214,7 +1214,7 @@ impl ConceptualRustType {
 
     // See comment in RustStruct::definite_info(), this is the same, returns a string expression
     // which evaluates to the length.
-    // self_expr is an expresison that evaluates to this RustType (e.g. member, etc) at the point where
+    // self_expr is an expression that evaluates to this RustType (e.g. member, etc) at the point where
     // the return of this function will be used.
     pub fn definite_info(&self, self_expr: &str, types: &IntermediateTypes) -> String {
         match self.expanded_field_count(types) {
@@ -1266,7 +1266,16 @@ impl ConceptualRustType {
     pub fn visit_types_excluding<F: FnMut(&Self)>(&self, types: &IntermediateTypes, f: &mut F, already_visited: &mut BTreeSet<RustIdent>) {
         f(self);
         match self {
-            Self::Alias(_ident, ty) => ty.visit_types_excluding(types, f, already_visited),
+            Self::Alias(ident, ty) => {
+                match ident {
+                    AliasIdent::Rust(rust_ident) => {
+                        if already_visited.insert(rust_ident.clone()) {
+                            ty.visit_types_excluding(types, f, already_visited)
+                        }
+                    },
+                    _ => ty.visit_types_excluding(types, f, already_visited)
+                };
+            },
             Self::Array(ty) => ty.conceptual_type.visit_types_excluding(types, f, already_visited),
             Self::Fixed(_) => (),
             Self::Map(k, v) => {

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -25,7 +25,6 @@ plain_arrays = [
 ]
 
 table = { * uint => text }
-
 table_arr_members = {
 	tab: { * text => text },
 	arr: [*uint],
@@ -78,3 +77,19 @@ map_with_defaults = {
 
 paren_size = uint .size (1)
 paren_cbor = bytes .cbor (text)
+
+; types below test codegen_table_type
+
+standalone_table = { * uint => text }
+standalone_text = { * text => text }
+
+embedded_table = { * uint => text }
+embedded_text = { * text => text }
+
+table_array_wrapper = [embedded_table]
+table_map_wrapper = { 721: embedded_table }
+
+text_array_wrapper = [embedded_text]
+text_map_wrapper = { 721: embedded_text }
+
+inline_wrapper = [{ * text => text }]


### PR DESCRIPTION
I noticed the WASM code outputted by the codegen had some issues:

## 1) Redundantly wrapped structs

If you have something like
```cddl
data = { * policy_id_v2 => { * asset_name_v2 => metadata_details } }
```
It would first generate a type for `{ * policy_id_v2 => { * asset_name_v2 => metadata_details } }` and then make `Data` an alias to that type. Instead, I made it so that Data is just directly the type instead of an alias


## 2) Redefining aliases instead of reusing them

If in the Rust crate we had something like  `type LabelMetadataV2 = BTree<...>`, instead of reusing `core::LabelMetadataV2` in the WASM type, it would instead just redefine the alias a new alias that happens to be the same.

I now made it properly just use `core::LabelMetadataV2` so the alias gets reused

## 3) Fix bug when two types use the same `name_for_wasm_map`

I switched `wasm_wrappers_generated.insert` to `wasm_wrappers_generated.contains`. This is because after the insert line, we were creating a type for `rust_ident` instead of `map_indent`, so this would cause a crash if some unrelated different struct needed to actually make a type with the name `map_indent`