### PR TITLE
Sorted outputted code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,15 +34,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +163,8 @@ dependencies = [
  "either",
  "nom",
  "once_cell",
+ "quote",
+ "syn",
  "which",
 ]
 
@@ -265,10 +258,11 @@ dependencies = [
 [[package]]
 name = "codegen"
 version = "0.2.0"
-source = "git+https://github.com/dcSpark/codegen?branch=master#f95a37241284c7f062b26f43ed3b69ae79f133eb"
+source = "git+https://github.com/dcSpark/codegen?branch=master#a31b2eff7adfd65dfdb10d6a4d7a83bd2f5d6010"
 dependencies = [
  "indexmap",
- "regex",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -789,9 +783,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.21"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbe448f377a7d6961e30f5955f9b8d106c3f5e449d493ee1b125c1d43c2b5179"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -811,8 +805,6 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax",
 ]
 
@@ -954,9 +946,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.103"
+version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a864042229133ada95abf3b54fdc62ef5ccabe9515b64717bcb9a1919e59445d"
+checksum = "1f4064b5b16e03ae50984a5a8ed5d4f8803e6bc1fd170a3cda91a1be4b18e3f5"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -255,9 +255,8 @@ dependencies = [
 
 [[package]]
 name = "codegen"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34c59e8a9b988977ec3bd61ab380cf1167048817ecd3d6999fac03657f85a609"
+version = "0.2.0"
+source = "git+https://github.com/dcSpark/codegen?branch=master#1c1aecc7fbc420d4dbade795447ad9f7b1cd43f6"
 dependencies = [
  "indexmap",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,6 +34,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc936419f96fa211c1b9166887b38e5e40b19958e5b895be7c1f93adec7071ac"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -256,9 +265,10 @@ dependencies = [
 [[package]]
 name = "codegen"
 version = "0.2.0"
-source = "git+https://github.com/dcSpark/codegen?branch=master#1c1aecc7fbc420d4dbade795447ad9f7b1cd43f6"
+source = "git+https://github.com/dcSpark/codegen?branch=master#f95a37241284c7f062b26f43ed3b69ae79f133eb"
 dependencies = [
  "indexmap",
+ "regex",
 ]
 
 [[package]]
@@ -801,6 +811,8 @@ version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ which-rustfmt = ["which"]
 cbor_event = "2.1.3"
 cddl = "0.9.1"
 clap = { version = "~3.1.5", features = ["derive"] }
-codegen = "0.1.3"
+codegen = { git = "https://github.com/dcSpark/codegen", branch = "master" }
 either = "1.5.3"
 once_cell = "1.17.0"
 nom = "7.1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,5 @@ either = "1.5.3"
 once_cell = "1.17.0"
 nom = "7.1.1"
 which = { version = "4.2.1", optional = true, default-features = false }
+syn = "1.0.107"
+quote = "1.0.23"

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -1845,7 +1845,7 @@ impl GenerationScope {
             let mut s = codegen::Struct::new(&array_type_ident.to_string());
             s
                 .vis("pub")
-                .tuple_field(format!("pub(crate) {}", &inner_type))
+                .tuple_field(Some("pub(crate)".to_string()), &inner_type)
                 .derive("Clone")
                 .derive("Debug")
                 .attr("wasm_bindgen");
@@ -2187,7 +2187,7 @@ fn create_base_wasm_wrapper<'a>(gen_scope: &GenerationScope, ident: &'a RustIden
     let name = &ident.to_string();
     if default_structure {
         let native_name = &format!("core::{}", name);
-        base.s.tuple_field(format!("pub(crate) {}", native_name));
+        base.s.tuple_field(Some("pub(crate)".to_string()), native_name);
         let mut from_wasm = codegen::Impl::new(name);
         from_wasm
             .impl_trait(format!("From<{}>", native_name))
@@ -2470,7 +2470,7 @@ fn codegen_table_type(gen_scope: &mut GenerationScope, types: &IntermediateTypes
     assert!(!key_type.cbor_types().contains(&CBORType::Special));
     let mut wrapper = create_base_wasm_struct(gen_scope, name, false);
     let inner_type = ConceptualRustType::name_for_rust_map(&key_type, &value_type, true);
-    wrapper.s.tuple_field(format!("pub(crate) {}", inner_type));
+    wrapper.s.tuple_field(Some("pub(crate)".to_string()), &inner_type);
     // new
     let mut new_func = codegen::Function::new("new");
     new_func
@@ -4176,7 +4176,7 @@ fn generate_wrapper_struct(gen_scope: &mut GenerationScope, types: &Intermediate
         }
         Some(enc_fields)
     } else {
-        s.tuple_field(format!("pub {}", field_type.for_rust_member(false)));
+        s.tuple_field(Some("pub".to_string()), field_type.for_rust_member(false));
         None
     };
     // TODO: is there a way to know if the encoding object is also copyable?


### PR DESCRIPTION
This PR makes that all the code outputted by the codegen is sorted, closing #126 

This makes it easier to compare diffs when regenerating code

**Note:** this PR isn't based on master but the `rustfmt` branch. It needs to be merged before this one.