### PR TITLE
@no_alias tag + to/from bytes rework + misc fixes + external types

### DIFF
--- a/src/comment_ast.rs
+++ b/src/comment_ast.rs
@@ -1,83 +1,95 @@
 extern crate nom;
 use nom::{
-  IResult,
-  bytes::complete::{tag, take_while1, take_while}, branch::alt, multi::many0,
+    IResult,
+    bytes::complete::{tag, take_while1, take_while}, branch::alt, multi::many0,
 };
 
 #[derive(Default, Debug, PartialEq)]
 pub struct RuleMetadata {
-  pub name: Option<String>,
-  pub is_newtype: bool,
+    pub name: Option<String>,
+    pub is_newtype: bool,
+    pub no_alias: bool,
 }
 
-fn merge_metadata(r1: &RuleMetadata, r2: &RuleMetadata) -> RuleMetadata {
+pub fn merge_metadata(r1: &RuleMetadata, r2: &RuleMetadata) -> RuleMetadata {
     RuleMetadata {
         name: match (r1.name.as_ref(), r2.name.as_ref()) {
             (Some(val1), Some(val2)) => panic!("Key \"name\" specified twice: {:?} {:?}", val1, val2),
             (val@Some(_), _) => val.cloned(),
             (_, val) => val.cloned()
         },
-        is_newtype: r1.is_newtype || r2.is_newtype
+        is_newtype: r1.is_newtype || r2.is_newtype,
+        no_alias: r1.no_alias || r2.no_alias,
     }
 }
 
 enum ParseResult {
-  NewType,
-  Name(String)
+    NewType,
+    Name(String),
+    DontGenAlias,
 }
 
 impl RuleMetadata {
-  fn from_parse_results(results: &[ParseResult]) -> RuleMetadata {
-    let mut base = RuleMetadata::default();
-    for result in results {
-      match result {
-        ParseResult::Name(name) => {
-          match base.name.as_ref() {
-            Some(old_name) => panic!("Key \"name\" specified twice: {:?} {:?}", old_name, name),
-            None => { base.name = Some(name.to_string()); }
-          }
-        },
-        ParseResult::NewType => { base.is_newtype = true; }
-      }
+    fn from_parse_results(results: &[ParseResult]) -> RuleMetadata {
+        let mut base = RuleMetadata::default();
+        for result in results {
+            match result {
+                ParseResult::Name(name) => {
+                    match base.name.as_ref() {
+                        Some(old_name) => panic!("Key \"name\" specified twice: {:?} {:?}", old_name, name),
+                        None => { base.name = Some(name.to_string()); }
+                    }
+                },
+                ParseResult::NewType => { base.is_newtype = true; },
+                ParseResult::DontGenAlias => { base.no_alias = true; },
+            }
+        }
+        base
     }
-    base
-  }
 }
 
 fn tag_name(input: &str) -> IResult<&str, ParseResult> {
-  let (input, _) = tag("@name")(input)?;
-  let (input, _) = take_while(char::is_whitespace)(input)?;
-  let (input, name) = take_while1(|ch| !char::is_whitespace(ch))(input)?;
+    let (input, _) = tag("@name")(input)?;
+    let (input, _) = take_while(char::is_whitespace)(input)?;
+    let (input, name) = take_while1(|ch| !char::is_whitespace(ch))(input)?;
 
-  Ok((input, ParseResult::Name(name.to_string())))
+    Ok((input, ParseResult::Name(name.to_string())))
 }
+
 fn tag_newtype(input: &str) -> IResult<&str, ParseResult> {
-  let (input, _) = tag("@newtype")(input)?;
+    let (input, _) = tag("@newtype")(input)?;
 
-  Ok((input, ParseResult::NewType))
+    Ok((input, ParseResult::NewType))
 }
-fn whitespace_then_tag(input: &str) -> IResult<&str, ParseResult> {
-  let (input, _) = take_while(char::is_whitespace)(input)?;
-  let (input, result) = alt((tag_name, tag_newtype))(input)?;
 
-  Ok((input, result))
+fn tag_no_alias(input: &str) -> IResult<&str, ParseResult> {
+    let (input, _) = tag("@no_alias")(input)?;
+
+    Ok((input, ParseResult::DontGenAlias))
+}
+
+fn whitespace_then_tag(input: &str) -> IResult<&str, ParseResult> {
+    let (input, _) = take_while(char::is_whitespace)(input)?;
+    let (input, result) = alt((tag_name, tag_newtype, tag_no_alias))(input)?;
+
+    Ok((input, result))
 }
 
 fn rule_metadata(input: &str) -> IResult<&str, RuleMetadata> {
-  let (input, parse_results) = many0(whitespace_then_tag)(input)?;
-  
+    let (input, parse_results) = many0(whitespace_then_tag)(input)?;
+    
 
-  Ok((input, RuleMetadata::from_parse_results(&parse_results)))
+    Ok((input, RuleMetadata::from_parse_results(&parse_results)))
 }
 
 
 impl <'a> From<Option<&'a cddl::ast::Comments<'a>>> for RuleMetadata {
-  fn from(comments: Option<&'a cddl::ast::Comments<'a>>) -> RuleMetadata {
-    match comments {
-      None => RuleMetadata::default(),
-      Some(c) => metadata_from_comments(&c.0)
+    fn from(comments: Option<&'a cddl::ast::Comments<'a>>) -> RuleMetadata {
+        match comments {
+            None => RuleMetadata::default(),
+            Some(c) => metadata_from_comments(&c.0)
+        }
     }
-  }
 }
 
 pub fn metadata_from_comments(comments: &[&str]) -> RuleMetadata {
@@ -92,32 +104,45 @@ pub fn metadata_from_comments(comments: &[&str]) -> RuleMetadata {
 
 #[test]
 fn parse_comment_name() {
-  assert_eq!(rule_metadata("@name foo"), Ok(("", RuleMetadata {
-    name: Some("foo".to_string()),
-    is_newtype: false,
-  })));
+    assert_eq!(rule_metadata("@name foo"), Ok(("", RuleMetadata {
+        name: Some("foo".to_string()),
+        is_newtype: false,
+        no_alias: false,
+    })));
 }
 
 #[test]
 fn parse_comment_newtype() {
-  assert_eq!(rule_metadata("@newtype"), Ok(("", RuleMetadata {
-    name: None,
-    is_newtype: true
-  })));
+    assert_eq!(rule_metadata("@newtype"), Ok(("", RuleMetadata {
+        name: None,
+        is_newtype: true,
+        no_alias: false,
+    })));
 }
 
 #[test]
 fn parse_comment_newtype_and_name() {
-  assert_eq!(rule_metadata("@newtype @name foo"), Ok(("", RuleMetadata {
-    name: Some("foo".to_string()),
-    is_newtype: true
-  })));
+    assert_eq!(rule_metadata("@newtype @name foo"), Ok(("", RuleMetadata {
+        name: Some("foo".to_string()),
+        is_newtype: true,
+        no_alias: false,
+    })));
 }
 
 #[test]
 fn parse_comment_newtype_and_name_inverse() {
-  assert_eq!(rule_metadata("@name foo @newtype"), Ok(("", RuleMetadata {
-    name: Some("foo".to_string()),
-    is_newtype: true
-  })));
+    assert_eq!(rule_metadata("@name foo @newtype"), Ok(("", RuleMetadata {
+        name: Some("foo".to_string()),
+        is_newtype: true,
+        no_alias: false,
+    })));
+}
+
+#[test]
+fn parse_comment_all() {
+    assert_eq!(rule_metadata("@no_alias @name foo @newtype"), Ok(("", RuleMetadata {
+        name: Some("foo".to_string()),
+        is_newtype: true,
+        no_alias: true,
+    })));
 }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -1834,7 +1834,6 @@ impl GenerationScope {
             }
             add_wasm_enum_getters(&mut wrapper.s_impl, name, &variants, None);
             wrapper.push(self, types);
-            //push_wasm_wrapper(self, name, s, s_impl);
         }
     }
 
@@ -2097,7 +2096,6 @@ impl<'a> WasmWrapper<'a> {
             .arg("native", native_name)
             .ret("Self")
             .line("Self(native)");
-            //.line(format!("Self({}(native))", native_name));
             self.from_wasm = Some(from_wasm);
         let mut from_native = codegen::Impl::new(native_name);
         from_native
@@ -3580,7 +3578,6 @@ fn codegen_group_choices(gen_scope: &mut GenerationScope, types: &IntermediateTy
         }
         // enum-getters
         add_wasm_enum_getters(&mut wrapper.s_impl, name, &variants, Some(rep));
-        //push_wasm_wrapper(gen_scope, name, s, s_impl);
         wrapper.push(gen_scope, types);
     }
 }

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -38,7 +38,7 @@ pub struct IntermediateTypes<'a> {
 impl<'a> IntermediateTypes<'a> {
     pub fn new() -> Self {
         let mut rust_structs = BTreeMap::new();
-        rust_structs.insert(RustIdent::new(CDDLIdent::new("int")), RustStruct::new_prelude(RustIdent::new(CDDLIdent::new("int"))));
+        rust_structs.insert(RustIdent::new(CDDLIdent::new("int")), RustStruct::new_extern(RustIdent::new(CDDLIdent::new("int"))));
         Self {
             plain_groups: BTreeMap::new(),
             type_aliases: Self::aliases(),
@@ -110,10 +110,8 @@ impl<'a> IntermediateTypes<'a> {
     pub fn new_type(&mut self, raw: &CDDLIdent) -> RustType {
         let alias_ident = AliasIdent::new(raw.clone());
         let resolved = match self.apply_type_aliases(&alias_ident) {
-            Some(ty) => match alias_ident {
-                AliasIdent::Reserved(_) => ty,
-                AliasIdent::Rust(_) => ty.as_alias(alias_ident.clone())
-            },
+            Some((ty, true)) => ty,
+            Some((ty, false)) => ty.as_alias(alias_ident.clone()),
             None => ConceptualRustType::Rust(RustIdent::new(raw.clone())).into(),
         };
         let resolved_inner = match &resolved.conceptual_type {
@@ -144,10 +142,13 @@ impl<'a> IntermediateTypes<'a> {
     }
 
     // see new_type() for why this is mut
-    pub fn apply_type_aliases(&mut self, alias_ident: &AliasIdent) -> Option<RustType> {
+    /// returns: (base type, if the alias should be substituted)
+    pub fn apply_type_aliases(&mut self, alias_ident: &AliasIdent) -> Option<(RustType, bool)>  {
         // Assumes we are not trying to pass in any kind of compound type (arrays, etc)
         match self.type_aliases.get(alias_ident) {
-            Some((alias, _, _)) => Some(alias.clone()),
+            Some((alias, gen_alias, _)) => {
+                Some((alias.clone(), !gen_alias))
+            }
             None => match alias_ident {
                 AliasIdent::Rust(_rust_ident) => None,
                 AliasIdent::Reserved(reserved) => if reserved == "int" {
@@ -157,7 +158,7 @@ impl<'a> IntermediateTypes<'a> {
                     // we auto-include only the parts of the cddl prelude necessary (and supported)
                     cddl_prelude(reserved).expect(&format!("Reserved ident {} not a part of cddl_prelude?", reserved));
                     self.emit_prelude(reserved.clone());
-                    Some(ConceptualRustType::Rust(RustIdent::new(CDDLIdent::new(format!("prelude_{}", reserved)))).into())
+                    Some((ConceptualRustType::Rust(RustIdent::new(CDDLIdent::new(format!("prelude_{}", reserved)))).into(), true))
                 },
             },
         }
@@ -613,6 +614,12 @@ mod idents {
     impl std::fmt::Display for RustIdent {
         fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
             write!(f, "{}", self.0)
+        }
+    }
+
+    impl AsRef<str> for RustIdent {
+        fn as_ref(&self) -> &str {
+            self.0.as_str()
         }
     }
 
@@ -1459,7 +1466,7 @@ pub enum RustStructType {
     /// This is a no-op in generation but to prevent lookups of things in the prelude
     /// e.g. `int` from not being resolved while still being able to detect it when
     /// referring to a struct that doesn't exist even after generation.
-    Prelude,
+    Extern,
 }
 
 impl RustStruct {
@@ -1524,11 +1531,11 @@ impl RustStruct {
         }
     }
 
-    pub fn new_prelude(ident: RustIdent) -> Self {
+    pub fn new_extern(ident: RustIdent) -> Self {
         Self {
             ident,
             tag: None,
-            variant: RustStructType::Prelude,
+            variant: RustStructType::Extern,
         }
     }
 
@@ -1559,7 +1566,7 @@ impl RustStruct {
             RustStructType::TypeChoice{ .. } => unreachable!("I don't think type choices should be using length?"),
             RustStructType::GroupChoice{ .. } => unreachable!("I don't think group choices should be using length?"),
             RustStructType::Wrapper{ .. } => unreachable!("wrapper types don't use length"),
-            RustStructType::Prelude{ .. } => panic!("do we need to look this up ever? will the prelude have structs with fields?"),
+            RustStructType::Extern{ .. } => panic!("do we need to look this up ever? will the prelude have structs with fields?"),
         }
     }
 
@@ -1574,7 +1581,7 @@ impl RustStruct {
             RustStructType::TypeChoice{ .. } => unreachable!("I don't think type choices should be using length?"),
             RustStructType::GroupChoice{ .. } => unreachable!("I don't think group choices should be using length?"),
             RustStructType::Wrapper{ .. } => unreachable!("wrapper types don't use length"),
-            RustStructType::Prelude{ .. } => panic!("do we need to look this up ever? will the prelude have structs with fields?"),
+            RustStructType::Extern{ .. } => panic!("do we need to look this up ever? will the prelude have structs with fields?"),
         }
     }
 
@@ -1590,7 +1597,7 @@ impl RustStruct {
             RustStructType::TypeChoice{ .. } => unreachable!("I don't think type choices should be using length?"),
             RustStructType::GroupChoice{ .. } => unreachable!("I don't think group choices should be using length?"),
             RustStructType::Wrapper{ .. } => unreachable!("wrapper types don't use length"),
-            RustStructType::Prelude{ .. } => panic!("do we need to look this up ever? will the prelude have structs with fields?"),
+            RustStructType::Extern{ .. } => panic!("do we need to look this up ever? will the prelude have structs with fields?"),
         }
     }
 
@@ -1603,7 +1610,7 @@ impl RustStruct {
             RustStructType::TypeChoice{ .. } => unreachable!("I don't think type choices should be using length?"),
             RustStructType::GroupChoice{ .. } => unreachable!("I don't think group choices should be using length?"),
             RustStructType::Wrapper{ .. } => unreachable!("wrapper types don't use length"),
-            RustStructType::Prelude{ .. } => panic!("do we need to look this up ever? will the prelude have structs with fields?"),
+            RustStructType::Extern{ .. } => panic!("do we need to look this up ever? will the prelude have structs with fields?"),
         }
     }
 
@@ -1621,7 +1628,7 @@ impl RustStruct {
                 range.conceptual_type.visit_types_excluding(types, f, already_visited);
             },
             RustStructType::Wrapper{ wrapped, .. } => wrapped.conceptual_type.visit_types_excluding(types, f, already_visited),
-            RustStructType::Prelude => (),
+            RustStructType::Extern => (),
         }
     }
 }
@@ -1813,7 +1820,7 @@ impl GenericInstance {
             RustStructType::Wrapper{ .. } => {
                 todo!("should we look this up in types to resolve?");
             },
-            RustStructType::Prelude => panic!("generics should not be used on types in the prelude (e.g. int)"),
+            RustStructType::Extern => panic!("generics should not be used on types in the prelude (e.g. int)"),
         };
         instance
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // to specific structs, and the existing comment parsing ast was not suited for this.
     // If, in the future, cddl released a feature flag to allow partial cddl we can just
     // remove all this and revert back the commit before this one for scope handling.
-    let input_files_content = input_files
+    let mut input_files_content = input_files
         .iter()
         .enumerate()
         .map(|(i, input_file)| {
@@ -67,9 +67,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             std::fs::read_to_string(input_file)
                 .map(|raw| format!("\n{}{} = \"{}\"\n{}\n", parsing::SCOPE_MARKER, i, scope, raw))
         }).collect::<Result<String, _>>()?;
+    // we also need to mark the extern marker to a placeholder struct that won't get codegened
+    input_files_content.push_str(&format!("{} = [0]", parsing::EXTERN_MARKER));
 
     // Plain group / scope marking
     let cddl = cddl::parser::cddl_from_str(&input_files_content, true)?;
+    //panic!("cddl: {:#?}", cddl);
     let pv = cddl::ast::parent::ParentVisitor::new(&cddl).unwrap();
     let mut types = IntermediateTypes::new();
     // mark scope and filter scope markers

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -3,7 +3,7 @@ use cddl::{ast::*, token};
 use either::{Either};
 use std::collections::{BTreeMap};
 
-use crate::comment_ast::{RuleMetadata, metadata_from_comments};
+use crate::comment_ast::{RuleMetadata, metadata_from_comments, merge_metadata};
 use crate::intermediate::{
     AliasIdent,
     CDDLIdent,
@@ -37,6 +37,7 @@ enum ControlOperator {
 }
 
 pub const SCOPE_MARKER: &'static str = "_CDDL_CODEGEN_SCOPE_MARKER_";
+pub const EXTERN_MARKER: &'static str = "_CDDL_CODEGEN_EXTERN_TYPE_";
 
 /// Some means it is a scope marker, containing the scope
 pub fn rule_is_scope_marker(cddl_rule: &cddl::ast::Rule) -> Option<String> {
@@ -58,20 +59,26 @@ pub fn rule_is_scope_marker(cddl_rule: &cddl::ast::Rule) -> Option<String> {
 pub fn parse_rule(types: &mut IntermediateTypes, parent_visitor: &ParentVisitor, cddl_rule: &cddl::ast::Rule) {
     match cddl_rule {
         cddl::ast::Rule::Type{ rule, .. } => {
-            // (1) is_type_choice_alternate ignored since shelley.cddl doesn't need it
-            //     It's used, but used for no reason as it is the initial definition
-            //     (which is also valid cddl), but it would be fine as = instead of /=
-            // (2) ignores control operators - only used in shelley spec to limit string length for application metadata
             let rust_ident = RustIdent::new(CDDLIdent::new(rule.name.to_string()));
-            let generic_params = rule
-                .generic_params
-                .as_ref()
-                .map(|gp| gp.params.iter().map(|id| RustIdent::new(CDDLIdent::new(id.param.to_string()))).collect::<Vec<_>>());
-            if rule.value.type_choices.len() == 1 {
-                let choice = &rule.value.type_choices.first().unwrap();
-                parse_type(types, parent_visitor, &rust_ident, choice, None, generic_params);
+            if rule.name.to_string() == EXTERN_MARKER {
+                // ignore - this was inserted by us so that cddl's parsing succeeds
+                // see comments in main.rs
             } else {
-                parse_type_choices(types, parent_visitor, &rust_ident, &rule.value.type_choices, None, generic_params);
+                // (1) is_type_choice_alternate ignored since shelley.cddl doesn't need it
+                //     It's used, but used for no reason as it is the initial definition
+                //     (which is also valid cddl), but it would be fine as = instead of /=
+                // (2) ignores control operators - only used in shelley spec to limit string length for application metadata
+
+                let generic_params = rule
+                    .generic_params
+                    .as_ref()
+                    .map(|gp| gp.params.iter().map(|id| RustIdent::new(CDDLIdent::new(id.param.to_string()))).collect::<Vec<_>>());
+                if rule.value.type_choices.len() == 1 {
+                    let choice = &rule.value.type_choices.first().unwrap();
+                    parse_type(types, parent_visitor, &rust_ident, choice, None, generic_params);
+                } else {
+                    parse_type_choices(types, parent_visitor, &rust_ident, &rule.value.type_choices, None, generic_params);
+                }
             }
         },
         cddl::ast::Rule::Group{ rule, .. } => {
@@ -121,7 +128,8 @@ fn parse_type_choices(types: &mut IntermediateTypes, parent_visitor: &ParentVisi
             Some(tag) => RustType::new(ConceptualRustType::Optional(Box::new(inner_rust_type))).tag(tag),
             None => RustType::new(ConceptualRustType::Optional(Box::new(inner_rust_type))),
         };
-        types.register_type_alias(name.clone(), final_type, true, true);
+        let rule_metadata = RuleMetadata::from(inner_type2.comments_after_type.as_ref());
+        types.register_type_alias(name.clone(), final_type, !rule_metadata.no_alias, !rule_metadata.no_alias);
     } else {
         let variants = create_variants_from_type_choices(types, parent_visitor, type_choices);
         let rust_struct = RustStruct::new_type_choice(name.clone(), tag, variants);
@@ -263,75 +271,82 @@ fn range_to_primitive(low: Option<i128>, high: Option<i128>) -> Option<Conceptua
 
 fn parse_type(types: &mut IntermediateTypes, parent_visitor: &ParentVisitor, type_name: &RustIdent, type_choice: &TypeChoice, outer_tag: Option<usize>, generic_params: Option<Vec<RustIdent>>) {
     let type1 = &type_choice.type1;
+    let rule_metadata = merge_metadata(
+        &RuleMetadata::from(type1.comments_after_type.as_ref()),
+        &RuleMetadata::from(type_choice.comments_after_type.as_ref()),
+    );
     match &type1.type2 {
         Type2::Typename{ ident, generic_args, .. } => {
-            // Note: this handles bool constants too, since we apply the type aliases and they resolve
-            // and there's no Type2::BooleanValue
-            let cddl_ident = CDDLIdent::new(ident.to_string());
-            let control = type1.operator.as_ref().map(|op| parse_control_operator(types, parent_visitor, &type1.type2, op));
-            match control {
-                Some(control) => {
-                    assert!(generic_params.is_none(), "Generics combined with range specifiers not supported");
-                    // TODO: what about aliases that resolve to these? is it even possible to know this at this stage?
-                    let field_type = || match cddl_ident.to_string().as_str() {
-                        "tstr" | "text" => ConceptualRustType::Primitive(Primitive::Str),
-                        "bstr" | "bytes" => ConceptualRustType::Primitive(Primitive::Bytes),
-                        other => panic!("range control specifiers not supported for type: {}", other),
-                    };
-                    match control {
-                        ControlOperator::Range(min_max) => {
-                            match cddl_ident.to_string().as_str() {
-                                "int" | "uint" => match range_to_primitive(min_max.0, min_max.1) {
-                                    Some(t) => types.register_type_alias(type_name.clone(), t.into(), true, true),
-                                    None => panic!("unsupported range for {:?}: {:?}", cddl_ident.to_string().as_str(), control)
-                                },
-                                _ => types.register_rust_struct(parent_visitor, RustStruct::new_wrapper(type_name.clone(), outer_tag, field_type().clone().into(), Some(min_max)))
-                            }
-                        },
-                        ControlOperator::CBOR(ty) => match field_type() {
-                            ConceptualRustType::Primitive(Primitive::Bytes) => {
-                                types.register_type_alias(type_name.clone(), ty.as_bytes(), true, true);
+            if ident.ident == EXTERN_MARKER {
+                types.register_rust_struct(parent_visitor, RustStruct::new_extern(type_name.clone()));
+            } else {
+                // Note: this handles bool constants too, since we apply the type aliases and they resolve
+                // and there's no Type2::BooleanValue
+                let cddl_ident = CDDLIdent::new(ident.to_string());
+                let control = type1.operator.as_ref().map(|op| parse_control_operator(types, parent_visitor, &type1.type2, op));
+                match control {
+                    Some(control) => {
+                        assert!(generic_params.is_none(), "Generics combined with range specifiers not supported");
+                        // TODO: what about aliases that resolve to these? is it even possible to know this at this stage?
+                        let field_type = || match cddl_ident.to_string().as_str() {
+                            "tstr" | "text" => ConceptualRustType::Primitive(Primitive::Str),
+                            "bstr" | "bytes" => ConceptualRustType::Primitive(Primitive::Bytes),
+                            other => panic!("range control specifiers not supported for type: {}", other),
+                        };
+                        match control {
+                            ControlOperator::Range(min_max) => {
+                                match cddl_ident.to_string().as_str() {
+                                    "int" | "uint" => match range_to_primitive(min_max.0, min_max.1) {
+                                        Some(t) => types.register_type_alias(type_name.clone(), t.into(), !rule_metadata.no_alias, !rule_metadata.no_alias),
+                                        None => panic!("unsupported range for {:?}: {:?}", cddl_ident.to_string().as_str(), control)
+                                    },
+                                    _ => types.register_rust_struct(parent_visitor, RustStruct::new_wrapper(type_name.clone(), outer_tag, field_type().clone().into(), Some(min_max)))
+                                }
                             },
-                            _ => panic!(".cbor is only allowed on bytes as per CDDL spec"),
-                        },
-                        ControlOperator::Default(default_value) => {
-                            let default_type = rust_type_from_type2(types, parent_visitor, &type1.type2)
-                                .default(default_value);
-                            types.register_type_alias(type_name.clone(), default_type, true, true);
-                        },
-                    }
-                },
-                None => {
-                    let mut concrete_type = types.new_type(&cddl_ident);
-                    if let ConceptualRustType::Alias(_ident, ty) = concrete_type.conceptual_type {
-                        concrete_type.conceptual_type = *ty;
-                    };
-                    match &generic_params {
-                        Some(_params) => {
-                            // this should be the only situation where you need this as otherwise the params would be unbound
-                            todo!("generics on defined types e.g. foo<T, U> = [T, U], bar<V> = foo<V, uint>");
-                            // TODO: maybe you could do this by resolving it here then storing the resolved one as GenericDef
-                        },
-                        None => {
-                            match generic_args {
-                                Some(arg) => {
-                                    // This is for named generic instances such as:
-                                    // foo = bar<text>
-                                    let generic_args = arg.args.iter().map(|a| rust_type_from_type1(types, parent_visitor, &a.arg)).collect();
-                                    types.register_generic_instance(GenericInstance::new(type_name.clone(), RustIdent::new(cddl_ident.clone()), generic_args))
+                            ControlOperator::CBOR(ty) => match field_type() {
+                                ConceptualRustType::Primitive(Primitive::Bytes) => {
+                                    types.register_type_alias(type_name.clone(), ty.as_bytes(), !rule_metadata.no_alias, !rule_metadata.no_alias);
                                 },
-                                None => {
-                                    let rule_metadata = RuleMetadata::from(type1.comments_after_type.as_ref());
-                                    if rule_metadata.is_newtype {
-                                        types.register_rust_struct(parent_visitor, RustStruct::new_wrapper(type_name.clone(), None, concrete_type, None)); 
-                                    } else {
-                                        types.register_type_alias(type_name.clone(), concrete_type, true, true);
+                                _ => panic!(".cbor is only allowed on bytes as per CDDL spec"),
+                            },
+                            ControlOperator::Default(default_value) => {
+                                let default_type = rust_type_from_type2(types, parent_visitor, &type1.type2)
+                                    .default(default_value);
+                                types.register_type_alias(type_name.clone(), default_type,  !rule_metadata.no_alias, !rule_metadata.no_alias);
+                            },
+                        }
+                    },
+                    None => {
+                        let mut concrete_type = types.new_type(&cddl_ident);
+                        if let ConceptualRustType::Alias(_ident, ty) = concrete_type.conceptual_type {
+                            concrete_type.conceptual_type = *ty;
+                        };
+                        match &generic_params {
+                            Some(_params) => {
+                                // this should be the only situation where you need this as otherwise the params would be unbound
+                                todo!("generics on defined types e.g. foo<T, U> = [T, U], bar<V> = foo<V, uint>");
+                                // TODO: maybe you could do this by resolving it here then storing the resolved one as GenericDef
+                            },
+                            None => {
+                                match generic_args {
+                                    Some(arg) => {
+                                        // This is for named generic instances such as:
+                                        // foo = bar<text>
+                                        let generic_args = arg.args.iter().map(|a| rust_type_from_type1(types, parent_visitor, &a.arg)).collect();
+                                        types.register_generic_instance(GenericInstance::new(type_name.clone(), RustIdent::new(cddl_ident.clone()), generic_args))
+                                    },
+                                    None => {
+                                        if rule_metadata.is_newtype {
+                                            types.register_rust_struct(parent_visitor, RustStruct::new_wrapper(type_name.clone(), None, concrete_type, None)); 
+                                        } else {
+                                            types.register_type_alias(type_name.clone(), concrete_type, !rule_metadata.no_alias, !rule_metadata.no_alias);
+                                        }
                                     }
                                 }
                             }
                         }
-                    }
-                },
+                    },
+                }
             }
         },
         Type2::Map{ group, .. } => {
@@ -364,16 +379,17 @@ fn parse_type(types: &mut IntermediateTypes, parent_visitor: &ParentVisitor, typ
                                 Some(ControlOperator::CBOR(ty)) => {
                                     let base_type = types
                                         .apply_type_aliases(&AliasIdent::new(CDDLIdent::new(ident.to_string())))
-                                        .expect("should not fail since ordered by dep graph");
+                                        .expect("should not fail since ordered by dep graph")
+                                        .0;
                                     assert_eq!(base_type.conceptual_type, ConceptualRustType::Primitive(Primitive::Bytes));
                                     assert_eq!(base_type.default, None);
                                     assert!(base_type.encodings.is_empty());
-                                    types.register_type_alias(type_name.clone(), ty.as_bytes().tag(tag_unwrap), true, true);
+                                    types.register_type_alias(type_name.clone(), ty.as_bytes().tag(tag_unwrap), !rule_metadata.no_alias, !rule_metadata.no_alias);
                                 },
                                 Some(ControlOperator::Range(min_max)) => {
                                     match ident.to_string().as_str() {
                                         "int" | "uint" => match range_to_primitive(min_max.0, min_max.1) {
-                                            Some(t) => types.register_type_alias(type_name.clone(), t.into(), true, true),
+                                            Some(t) => types.register_type_alias(type_name.clone(), t.into(), !rule_metadata.no_alias, !rule_metadata.no_alias),
                                             None => panic!("unsupported range for {:?}: {:?}", ident.to_string().as_str(), control)
                                         },
                                         _ => types.register_rust_struct(parent_visitor, RustStruct::new_wrapper(type_name.clone(), *tag, new_type, Some(min_max)))
@@ -383,15 +399,14 @@ fn parse_type(types: &mut IntermediateTypes, parent_visitor: &ParentVisitor, typ
                                     let default_tagged_type = rust_type_from_type2(types, parent_visitor, &inner_type.type1.type2)
                                         .default(default_value)
                                         .tag(tag_unwrap);
-                                    types.register_type_alias(type_name.clone(), default_tagged_type, true, true);
+                                    types.register_type_alias(type_name.clone(), default_tagged_type, !rule_metadata.no_alias, !rule_metadata.no_alias);
                                 },
                                 None => {
-                                    // TODO: this would be fixed if we ordered definitions via a dependency graph to begin with
-                                    // which would also allow us to do a single pass instead of many like we do now
                                     let base_type = types
                                         .apply_type_aliases(&AliasIdent::new(CDDLIdent::new(ident.to_string())))
-                                        .expect("should not fail since ordered by dep graph");
-                                    types.register_type_alias(type_name.clone(), base_type.tag(tag_unwrap), true, true);
+                                        .expect("should not fail since ordered by dep graph")
+                                        .0;
+                                    types.register_type_alias(type_name.clone(), base_type.tag(tag_unwrap), !rule_metadata.no_alias, !rule_metadata.no_alias);
                                 },
                             }
                         },
@@ -416,7 +431,7 @@ fn parse_type(types: &mut IntermediateTypes, parent_visitor: &ParentVisitor, typ
                 },
                 _ => fallback_type
             };
-            types.register_type_alias(type_name.clone(), base_type.into(), true, true);
+            types.register_type_alias(type_name.clone(), base_type.into(), !rule_metadata.no_alias, !rule_metadata.no_alias);
         },
         Type2::UintValue{ value, .. } => {
             let fallback_type = ConceptualRustType::Fixed(FixedValue::Uint(*value));
@@ -431,10 +446,10 @@ fn parse_type(types: &mut IntermediateTypes, parent_visitor: &ParentVisitor, typ
                 },
                 _ => fallback_type
             };
-            types.register_type_alias(type_name.clone(), base_type.into(), true, true);
+            types.register_type_alias(type_name.clone(), base_type.into(), !rule_metadata.no_alias, !rule_metadata.no_alias);
         },
         Type2::TextValue{ value, .. } => {
-            types.register_type_alias(type_name.clone(), ConceptualRustType::Fixed(FixedValue::Text(value.to_string())).into(), true, true);
+            types.register_type_alias(type_name.clone(), ConceptualRustType::Fixed(FixedValue::Text(value.to_string())).into(), !rule_metadata.no_alias, !rule_metadata.no_alias);
         },
         x => {
             panic!("\nignored typename {} -> {:?}\n", type_name, x);

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,11 @@
 use std::io::Write;
 
-fn run_test(dir: &str, options: &[&str], export_suffix: Option<&str>) {
+fn run_test(
+    dir: &str,
+    options: &[&str],
+    export_suffix: Option<&str>,
+    external_core_file_path: Option<std::path::PathBuf>,
+    external_wasm_file_path: Option<std::path::PathBuf>) {
     use std::str::FromStr;
     let export_path = match export_suffix {
         Some(suffix) => format!("export_{}", suffix),
@@ -30,12 +35,19 @@ fn run_test(dir: &str, options: &[&str], export_suffix: Option<&str>) {
         .append(true)
         .open(test_path.join(format!("{}/core/src/lib.rs", export_path)))
         .unwrap();
+    // copy external file in too (if needed) too
+    if let Some(external_core_file_path) = external_core_file_path {
+        let extern_rs = std::fs::read_to_string(external_core_file_path).unwrap();
+        lib_rs.write("\n\n".as_bytes()).unwrap();
+        lib_rs.write_all(extern_rs.as_bytes()).unwrap();
+    }
     let deser_test_rs = std::fs::read_to_string(std::path::PathBuf::from_str("tests").unwrap().join("deser_test")).unwrap();
     lib_rs.write("\n\n".as_bytes()).unwrap();
     lib_rs.write_all(deser_test_rs.as_bytes()).unwrap();
     let test_rs = std::fs::read_to_string(test_path.join("tests.rs")).unwrap();
     lib_rs.write("\n\n".as_bytes()).unwrap();
     lib_rs.write_all(test_rs.as_bytes()).unwrap();
+    std::mem::drop(lib_rs);
     // run tests in generated code
     println!("   ------ testing ------");
     let cargo_test = std::process::Command::new("cargo")
@@ -48,8 +60,22 @@ fn run_test(dir: &str, options: &[&str], export_suffix: Option<&str>) {
     }
     println!("test stdout:\n{}", String::from_utf8(cargo_test.stdout).unwrap());
     assert!(cargo_test.status.success());
+
+    // wasm
     let wasm_export_dir = test_path.join(format!("{}/wasm", export_path));
     let wasm_test_dir = test_path.join("tests_wasm.rs");
+    // copy external wasm defs if they exist
+    if let Some(external_wasm_file_path) = external_wasm_file_path {
+        println!("trying to open: {:?}", external_wasm_file_path);
+        let mut wasm_lib_rs = std::fs::OpenOptions::new()
+            .write(true)
+            .append(true)
+            .open(test_path.join(format!("{}/wasm/src/lib.rs", export_path)))
+            .unwrap();
+        let extern_rs = std::fs::read_to_string(external_wasm_file_path).unwrap();
+        wasm_lib_rs.write("\n\n".as_bytes()).unwrap();
+        wasm_lib_rs.write_all(extern_rs.as_bytes()).unwrap();
+    }
     if wasm_test_dir.exists() {
         println!("   ------ testing (wasm) ------");
         let cargo_test_wasm = std::process::Command::new("cargo")
@@ -77,30 +103,35 @@ fn run_test(dir: &str, options: &[&str], export_suffix: Option<&str>) {
 
 #[test]
 fn core_with_wasm() {
-    run_test("core", &[], Some("wasm"));
+    use std::str::FromStr;
+    let extern_core_path = std::path::PathBuf::from_str("tests").unwrap().join("external_core_defs");
+    let extern_wasm_path = std::path::PathBuf::from_str("tests").unwrap().join("external_wasm_defs");
+    run_test("core", &[], Some("wasm"), Some(extern_core_path), Some(extern_wasm_path));
 }
 
 #[test]
 fn core_no_wasm() {
-    run_test("core", &["--wasm=false"], None);
+    use std::str::FromStr;
+    let extern_core_path = std::path::PathBuf::from_str("tests").unwrap().join("external_core_defs");
+    run_test("core", &["--wasm=false"], None, Some(extern_core_path), None);
 }
 
 #[test]
 fn comment_dsl() {
-    run_test("comment-dsl", &["--preserve-encodings=true"], Some("wasm"));
+    run_test("comment-dsl", &["--preserve-encodings=true"], Some("wasm"), None , None);
 }
 
 #[test]
 fn preserve_encodings() {
-    run_test("preserve-encodings", &["--preserve-encodings=true"], None);
+    run_test("preserve-encodings", &["--preserve-encodings=true"], None, None, None);
 }
 
 #[test]
 fn canonical() {
-    run_test("canonical", &["--preserve-encodings=true", "--canonical-form=true"], None);
+    run_test("canonical", &["--preserve-encodings=true", "--canonical-form=true"], None, None, None);
 }
 
 #[test]
 fn rust_wasm_split() {
-    run_test("rust-wasm-split", &[], None);
+    run_test("rust-wasm-split", &[], None, None, None);
 }

--- a/static/prelude.rs
+++ b/static/prelude.rs
@@ -118,28 +118,3 @@ impl From<cbor_event::Error> for DeserializeError {
         }
     }
 }
-
-// same as cbor_event::de::Deserialize but with our DeserializeError
-pub trait Deserialize {
-    fn deserialize<R: BufRead + Seek>(
-        raw: &mut Deserializer<R>,
-    ) -> Result<Self, DeserializeError> where Self: Sized;
-}
-
-impl<T: cbor_event::de::Deserialize> Deserialize for T {
-    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<T, DeserializeError> {
-        T::deserialize(raw).map_err(DeserializeError::from)
-    }
-}
-
-pub trait FromBytes {
-    fn from_bytes(data: Vec<u8>) -> Result<Self, DeserializeError> where Self: Sized;
-}
-
-impl<T: Deserialize + Sized> FromBytes for T {
-    fn from_bytes(data: Vec<u8>) -> Result<Self, DeserializeError> {
-        let mut raw = Deserializer::from(std::io::Cursor::new(data));
-        Self::deserialize(&mut raw)
-    }
-}
-

--- a/static/serialization.rs
+++ b/static/serialization.rs
@@ -1,0 +1,17 @@
+// same as cbor_event::de::Deserialize but with our DeserializeError
+pub trait Deserialize {
+    fn from_cbor_bytes(data: &[u8]) -> Result<Self, DeserializeError> where Self: Sized {
+        let mut raw = Deserializer::from(std::io::Cursor::new(data));
+        Self::deserialize(&mut raw)
+    }
+
+    fn deserialize<R: BufRead + Seek>(
+        raw: &mut Deserializer<R>,
+    ) -> Result<Self, DeserializeError> where Self: Sized;
+}
+
+impl<T: cbor_event::de::Deserialize> Deserialize for T {
+    fn deserialize<R: BufRead + Seek>(raw: &mut Deserializer<R>) -> Result<T, DeserializeError> {
+        T::deserialize(raw).map_err(DeserializeError::from)
+    }
+}

--- a/static/serialization_non_force_canonical.rs
+++ b/static/serialization_non_force_canonical.rs
@@ -5,14 +5,14 @@ pub trait SerializeEmbeddedGroup {
     ) -> cbor_event::Result<&'a mut Serializer<W>>;
 }
 
-pub trait ToBytes {
-  fn to_bytes(&self) -> Vec<u8>;
+pub trait ToCBORBytes {
+    fn to_cbor_bytes(&self) -> Vec<u8>;
 }
 
-impl<T: cbor_event::se::Serialize> ToBytes for T {
-  fn to_bytes(&self) -> Vec<u8> {
-      let mut buf = Serializer::new_vec();
-      self.serialize(&mut buf).unwrap();
-      buf.finalize()
-  }
+impl<T: cbor_event::se::Serialize> ToCBORBytes for T {
+    fn to_cbor_bytes(&self) -> Vec<u8> {
+        let mut buf = Serializer::new_vec();
+        self.serialize(&mut buf).unwrap();
+        buf.finalize()
+    }
 }

--- a/static/serialization_non_preserve.rs
+++ b/static/serialization_non_preserve.rs
@@ -1,44 +1,48 @@
 pub struct CBORReadLen {
-  deser_len: cbor_event::Len,
-  read: u64,
+    deser_len: cbor_event::Len,
+    read: u64,
 }
 
 impl CBORReadLen {
-  pub fn new(len: cbor_event::Len) -> Self {
-      Self {
-          deser_len: len,
-          read: 0,
-      }
-  }
+    pub fn new(len: cbor_event::Len) -> Self {
+        Self {
+            deser_len: len,
+            read: 0,
+        }
+    }
 
-  // Marks {n} values as being read, and if we go past the available definite length
-  // given by the CBOR, we return an error.
-  pub fn read_elems(&mut self, count: usize) -> Result<(), DeserializeFailure> {
-      match self.deser_len {
-          cbor_event::Len::Len(n) => {
-              self.read += count as u64;
-              if self.read > n {
-                  Err(DeserializeFailure::DefiniteLenMismatch(n, None))
-              } else {
-                  Ok(())
-              }
-          },
-          cbor_event::Len::Indefinite => Ok(()),
-      }
-  }
+    pub fn read(&self) -> u64 {
+        self.read
+    }
 
-  pub fn finish(&self) -> Result<(), DeserializeFailure> {
-      match self.deser_len {
-          cbor_event::Len::Len(n) => {
-              if self.read == n {
-                  Ok(())
-              } else {
-                  Err(DeserializeFailure::DefiniteLenMismatch(n, Some(self.read)))
-              }
-          },
-          cbor_event::Len::Indefinite => Ok(()),
-      }
-  }
+    // Marks {n} values as being read, and if we go past the available definite length
+    // given by the CBOR, we return an error.
+    pub fn read_elems(&mut self, count: usize) -> Result<(), DeserializeFailure> {
+        match self.deser_len {
+            cbor_event::Len::Len(n) => {
+                self.read += count as u64;
+                if self.read > n {
+                    Err(DeserializeFailure::DefiniteLenMismatch(n, None))
+                } else {
+                    Ok(())
+                }
+            },
+            cbor_event::Len::Indefinite => Ok(()),
+        }
+    }
+
+    pub fn finish(&self) -> Result<(), DeserializeFailure> {
+        match self.deser_len {
+            cbor_event::Len::Len(n) => {
+                if self.read == n {
+                    Ok(())
+                } else {
+                    Err(DeserializeFailure::DefiniteLenMismatch(n, Some(self.read)))
+                }
+            },
+            cbor_event::Len::Indefinite => Ok(()),
+        }
+    }
 }
 
 pub trait DeserializeEmbeddedGroup {

--- a/static/serialization_preserve_force_canonical.rs
+++ b/static/serialization_preserve_force_canonical.rs
@@ -54,21 +54,23 @@ impl StringEncoding {
 }
 
 pub trait Serialize {
+    fn to_canonical_cbor_bytes(&self) -> Vec<u8> {
+        let mut buf = Serializer::new_vec();
+        self.serialize(&mut buf, true).unwrap();
+        buf.finalize()
+    }
+
+    fn to_cbor_bytes(&self) -> Vec<u8> {
+        let mut buf = Serializer::new_vec();
+        self.serialize(&mut buf, false).unwrap();
+        buf.finalize()
+    }
+
     fn serialize<'a, W: Write + Sized>(
         &self,
         serializer: &'a mut Serializer<W>,
         force_canonical: bool,
     ) -> cbor_event::Result<&'a mut Serializer<W>>;
-}
-
-impl<T: cbor_event::se::Serialize> Serialize for T {
-    fn serialize<'a, W: Write + Sized>(
-        &self,
-        serializer: &'a mut Serializer<W>,
-        _force_canonical: bool,
-    ) -> cbor_event::Result<&'a mut Serializer<W>> {
-        <T as cbor_event::se::Serialize>::serialize(self, serializer)
-    }
 }
 
 pub trait SerializeEmbeddedGroup {
@@ -77,17 +79,4 @@ pub trait SerializeEmbeddedGroup {
         serializer: &'a mut Serializer<W>,
         force_canonical: bool,
     ) -> cbor_event::Result<&'a mut Serializer<W>>;
-}
-
-
-pub trait ToBytes {
-    fn to_bytes(&self, force_canonical: bool) -> Vec<u8>;
-}
-
-impl<T: Serialize> ToBytes for T {
-    fn to_bytes(&self, force_canonical: bool) -> Vec<u8> {
-        let mut buf = Serializer::new_vec();
-        self.serialize(&mut buf, force_canonical).unwrap();
-        buf.finalize()
-    }
 }

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -86,3 +86,9 @@ no_alias = [
 	no_alias_u32,
 	no_alias_u64
 ]
+
+external_foo = _CDDL_CODEGEN_EXTERN_TYPE_
+
+externs = [
+	external_foo
+]

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -78,3 +78,11 @@ map_with_defaults = {
 
 paren_size = uint .size (1)
 paren_cbor = bytes .cbor (text)
+
+no_alias_u32 = 0..4294967295 ; @no_alias
+no_alias_u64 = uint .size 8 ; @no_alias
+
+no_alias = [
+	no_alias_u32,
+	no_alias_u64
+]

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -169,4 +169,10 @@ mod tests {
         assert!(!lib_rs.contains("pub type NoAliasU32"));
         assert!(!lib_rs.contains("pub type NoAliasU64"));
     }
+
+    #[test]
+    fn externs() {
+        let externs = Externs::new(ExternalFoo::new(436, String::from("jfkdsjfd"), vec![1, 1, 1]));
+        deser_test(&externs);
+    }
 }

--- a/tests/deser_test
+++ b/tests/deser_test
@@ -3,12 +3,6 @@ static BREAK: u8 = 0xff;
 static ARR_INDEF: u8 = 0x9f;
 static MAP_INDEF: u8 = 0xbf;
 
-// to work around JsValue error types (TODO: we should fix this in cddl-codegen)
-fn from_bytes<T: Deserialize + Sized>(data: Vec<u8>) -> Result<T, DeserializeError> {
-    let mut raw = Deserializer::from(std::io::Cursor::new(data));
-    T::deserialize(&mut raw)
-}
-
 fn arr_def(len: u8) -> Vec<u8> {
     assert!(len <= 0x17);
     vec![0x80u8 + len]
@@ -82,7 +76,7 @@ fn print_cbor_types(obj_name: &str, vec: &Vec<u8>) {
             if let cbor_event::LenSz::Len(n, _) = len {
                 *n -= 1;
             }
-        };
+        }
     };
     let reduce_depth = |lens: &mut Vec<cbor_event::LenSz>| {
         while let Some(cbor_event::LenSz::Len(0, _)) = lens.last() {

--- a/tests/external_core_defs
+++ b/tests/external_core_defs
@@ -1,0 +1,58 @@
+#[derive(Clone, Debug)]
+pub struct ExternalFoo {
+    pub index_0: u64,
+    pub index_1: String,
+    pub index_2: Vec<u8>,
+}
+
+impl ExternalFoo {
+    pub fn new(index_0: u64, index_1: String, index_2: Vec<u8>) -> Self {
+        Self {
+            index_0,
+            index_1,
+            index_2,
+        }
+    }
+}
+
+impl cbor_event::se::Serialize for ExternalFoo {
+    fn serialize<'se, W: Write>(
+        &self,
+        serializer: &'se mut Serializer<W>,
+    ) -> cbor_event::Result<&'se mut Serializer<W>> {
+        serializer.write_array(cbor_event::Len::Len(3))?;
+        serializer.write_unsigned_integer(self.index_0)?;
+        serializer.write_text(&self.index_1)?;
+        serializer.write_bytes(&self.index_2)?;
+        Ok(serializer)
+    }
+}
+
+impl Deserialize for ExternalFoo {
+    fn deserialize<R: BufRead + std::io::Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
+        let len = raw.array()?;
+        let mut read_len = CBORReadLen::new(len);
+        read_len.read_elems(3)?;
+        (|| -> Result<_, DeserializeError> {
+            let index_0 = Ok(raw.unsigned_integer()? as u64)
+                .map_err(|e: DeserializeError| e.annotate("index_0"))?;
+            let index_1 =
+                Ok(raw.text()? as String).map_err(|e: DeserializeError| e.annotate("index_1"))?;
+            let index_2 =
+                Ok(raw.bytes()? as Vec<u8>).map_err(|e: DeserializeError| e.annotate("index_2"))?;
+            match len {
+                cbor_event::Len::Len(_) => (),
+                cbor_event::Len::Indefinite => match raw.special()? {
+                    CBORSpecial::Break => (),
+                    _ => return Err(DeserializeFailure::EndingBreakMissing.into()),
+                },
+            }
+            Ok(ExternalFoo {
+                index_0,
+                index_1,
+                index_2,
+            })
+        })()
+        .map_err(|e| e.annotate("ExternalFoo"))
+    }
+}

--- a/tests/external_wasm_defs
+++ b/tests/external_wasm_defs
@@ -1,0 +1,50 @@
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ExternalFoo(core::ExternalFoo);
+
+#[wasm_bindgen]
+impl ExternalFoo {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        core::serialization::ToCBORBytes::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ExternalFoo, JsValue> {
+        core::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn index_0(&self) -> u64 {
+        self.0.index_0
+    }
+
+    pub fn index_1(&self) -> String {
+        self.0.index_1.clone()
+    }
+
+    pub fn index_2(&self) -> Vec<u8> {
+        self.0.index_2.clone()
+    }
+
+    pub fn new(index_0: u64, index_1: String, index_2: Vec<u8>) -> Self {
+        Self(core::ExternalFoo::new(index_0, index_1, index_2))
+    }
+}
+
+impl From<core::ExternalFoo> for ExternalFoo {
+    fn from(native: core::ExternalFoo) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ExternalFoo> for core::ExternalFoo {
+    fn from(wasm: ExternalFoo) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<core::ExternalFoo> for ExternalFoo {
+    fn as_ref(&self) -> &core::ExternalFoo {
+        &self.0
+    }
+}

--- a/tests/rust-wasm-split/tests.rs
+++ b/tests/rust-wasm-split/tests.rs
@@ -2,11 +2,11 @@
 mod tests {
     use super::*;
 
-    fn deser_test<T: Deserialize + ToBytes>(orig: &T) {
-        print_cbor_types("orig", &orig.to_bytes());
-        let deser = T::deserialize(&mut Deserializer::from(std::io::Cursor::new(orig.to_bytes()))).unwrap();
-        print_cbor_types("deser", &deser.to_bytes());
-        assert_eq!(orig.to_bytes(), deser.to_bytes());
+    fn deser_test<T: Deserialize + ToCBORBytes>(orig: &T) {
+        print_cbor_types("orig", &orig.to_cbor_bytes());
+        let deser = T::deserialize(&mut Deserializer::from(std::io::Cursor::new(orig.to_cbor_bytes()))).unwrap();
+        print_cbor_types("deser", &deser.to_cbor_bytes());
+        assert_eq!(orig.to_cbor_bytes(), deser.to_cbor_bytes());
     }
 
     #[test]


### PR DESCRIPTION
Aliases are not generated if you tag comments by ; @no_alias This is useful for example in babbage.cddl's `int64 = -9223372036854775808 .. 9223372036854775807 ; @no_alias` to avoid generating this.

Externally-defined types can be marked by doing:
```
address = _CDDL_CODEGEN_EXTERN_TYPE_
```
to tell cddl-codegen that this represents a type that should have its Serialize/Deserialize traits used directly (e.g. if it were a self-contained rust type) and to not worry about its definition not being present. This is very useful when you have types that are hand-written due to having a more complicated structure than could be code-generated (e.g. the spec is just `bytes` but really there is a complicated binary format here e.g. crypto stuff). This removes the need for the old hack we had to do where you'd define it as something like `address = [0]` then have to go through and manually remove any generated code relating to it after the fact.

The to/from bytes were reworked to have both a `to_cbor_bytes()` and `to_canonical_cbor_bytes()` instead a possibly more confusing bool param. `from_bytes()` is renamed to `from_cbor_bytes()` as well to make it more explicit. This helps with how CML is implemented right now to match that code better.

ToBytes trait renamed to ToCBORBytes and is only used for non-canonical-preserve builds so we can avoid using cbor_event::Serialize as well as our own Serialize when not needed.

Misc fixes:
* bool serialization changed to not rely on cbor_event::Serialize
* tests updated for all changes + removed old TODO
* AsRef trait now generated for wasm wrappers to help for by-ref access to the underlying struct without needing to clone it with Into