### PR TITLE
Multi-file json-gen schema work + less imports

### DIFF
--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -143,18 +143,17 @@ impl<'a> IntermediateTypes<'a> {
                     set_ref(refs, types, current_scope, rust_ident)
                 }
                 ConceptualRustType::Array(elem_ty) => {
-                    if wasm && !elem_ty.directly_wasm_exposable() {
-                        // TODO: we should be doing array wrappers where they are declared or used
+                    if wasm && !elem_ty.directly_wasm_exposable() && current_scope != "lib" {
+                        // TODO: we should be doing array wrappers where they are declared or used,
                         // but for the latter, what to do if multiple places use it? default to lib?
-                        if current_scope != "lib" {
-                            let arr_wrapper_ident =
-                                RustIdent::new(CDDLIdent::new(elem_ty.name_as_wasm_array()));
-                            refs.entry(current_scope.to_owned())
-                                .or_default()
-                                .entry("lib".to_owned())
-                                .or_default()
-                                .insert(arr_wrapper_ident);
-                        }
+                        // issue: https://github.com/dcSpark/cddl-codegen/issues/138
+                        let arr_wrapper_ident =
+                            RustIdent::new(CDDLIdent::new(elem_ty.name_as_wasm_array()));
+                        refs.entry(current_scope.to_owned())
+                            .or_default()
+                            .entry("lib".to_owned())
+                            .or_default()
+                            .insert(arr_wrapper_ident);
                     } else {
                         mark_refs(refs, types, wasm, current_scope, elem_ty);
                     }
@@ -163,18 +162,17 @@ impl<'a> IntermediateTypes<'a> {
                     // nothing to import
                 }
                 ConceptualRustType::Map(key, value) => {
-                    if wasm {
-                        // TODO: we should be doing map wrappers where they are declared or used
-                        // but for the latter, what to do if multiple places use it? default to lib?
-                        if current_scope != "lib" {
-                            let map_wrapper_ident =
-                                ConceptualRustType::name_for_wasm_map(key, value);
-                            refs.entry(current_scope.to_owned())
-                                .or_default()
-                                .entry("lib".to_owned())
-                                .or_default()
-                                .insert(map_wrapper_ident);
-                        }
+                    if wasm && current_scope != "lib" {
+                        // TODO: we should be doing map wrappers where they are declared or used,
+                        // but for the former what if the key/value types are in different modules,
+                        // and for the latter, what to do if multiple places use it? default to lib?
+                        // issue: https://github.com/dcSpark/cddl-codegen/issues/138
+                        let map_wrapper_ident = ConceptualRustType::name_for_wasm_map(key, value);
+                        refs.entry(current_scope.to_owned())
+                            .or_default()
+                            .entry("lib".to_owned())
+                            .or_default()
+                            .insert(map_wrapper_ident);
                     } else {
                         mark_refs(refs, types, wasm, current_scope, key);
                         mark_refs(refs, types, wasm, current_scope, value);

--- a/static/serialization_preserve.rs
+++ b/static/serialization_preserve.rs
@@ -52,11 +52,11 @@ pub trait DeserializeEmbeddedGroup {
 #[inline]
 fn sz_max(sz: cbor_event::Sz) -> u64 {
     match sz {
-        Sz::Inline => 23u64,
-        Sz::One => u8::MAX as u64,
-        Sz::Two => u16::MAX as u64,
-        Sz::Four => u32::MAX as u64,
-        Sz::Eight => u64::MAX,
+        cbor_event::Sz::Inline => 23u64,
+        cbor_event::Sz::One => u8::MAX as u64,
+        cbor_event::Sz::Two => u16::MAX as u64,
+        cbor_event::Sz::Four => u32::MAX as u64,
+        cbor_event::Sz::Eight => u64::MAX,
     }
 }
 
@@ -89,8 +89,8 @@ impl From<cbor_event::LenSz> for LenEncoding {
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum StringEncoding {
     Canonical,
-    Indefinite(Vec<(u64, Sz)>),
-    Definite(Sz),
+    Indefinite(Vec<(u64, cbor_event::Sz)>),
+    Definite(cbor_event::Sz),
 }
 
 impl Default for StringEncoding {

--- a/static/serialization_preserve_force_canonical.rs
+++ b/static/serialization_preserve_force_canonical.rs
@@ -1,12 +1,12 @@
 #[inline]
-fn fit_sz(len: u64, sz: Option<cbor_event::Sz>, force_canonical: bool) -> Sz {
+fn fit_sz(len: u64, sz: Option<cbor_event::Sz>, force_canonical: bool) -> cbor_event::Sz {
     match sz {
         Some(sz) => if !force_canonical && len <= sz_max(sz) {
             sz
         } else {
-            Sz::canonical(len)
+            cbor_event::Sz::canonical(len)
         },
-        None => Sz::canonical(len),
+        None => cbor_event::Sz::canonical(len),
     }
 }
 
@@ -29,7 +29,7 @@ impl LenEncoding {
 
     pub fn end<'a, W: Write + Sized>(&self, serializer: &'a mut Serializer<W>, force_canonical: bool) -> cbor_event::Result<&'a mut Serializer<W>> {
         if !force_canonical && *self == Self::Indefinite {
-            serializer.write_special(CBORSpecial::Break)?;
+            serializer.write_special(cbor_event::Special::Break)?;
         }
         Ok(serializer)
     }

--- a/static/serialization_preserve_non_force_canonical.rs
+++ b/static/serialization_preserve_non_force_canonical.rs
@@ -1,12 +1,12 @@
 #[inline]
-fn fit_sz(len: u64, sz: Option<cbor_event::Sz>) -> Sz {
+fn fit_sz(len: u64, sz: Option<cbor_event::Sz>) -> cbor_event::Sz {
     match sz {
         Some(sz) => if len <= sz_max(sz) {
             sz
         } else {
-            Sz::canonical(len)
+            cbor_event::Sz::canonical(len)
         },
-        None => Sz::canonical(len),
+        None => cbor_event::Sz::canonical(len),
     }
 }
 
@@ -25,7 +25,7 @@ impl LenEncoding {
 
     pub fn end<'a, W: Write + Sized>(&self, serializer: &'a mut Serializer<W>) -> cbor_event::Result<&'a mut Serializer<W>> {
         if *self == Self::Indefinite {
-            serializer.write_special(CBORSpecial::Break)?;
+            serializer.write_special(cbor_event::Special::Break)?;
         }
         Ok(serializer)
     }

--- a/tests/canonical/tests.rs
+++ b/tests/canonical/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cbor_event::StringLenSz;
+    use cbor_event::{Sz, StringLenSz};
 
     fn deser_test_orig<T: Deserialize + Serialize>(orig: &T) {
         print_cbor_types("orig (original enc)", &orig.to_cbor_bytes());

--- a/tests/external_rust_defs_multifile
+++ b/tests/external_rust_defs_multifile
@@ -1,4 +1,7 @@
-#[derive(Clone, Debug)]
+// doesn't actually preserve encodings - just different so that it compiles
+// also contains JSON schemas
+
+#[derive(Clone, Debug, serde::Deserialize, serde::Serialize, schemars::JsonSchema)]
 pub struct ExternalFoo {
     pub index_0: u64,
     pub index_1: String,
@@ -31,7 +34,7 @@ impl cbor_event::se::Serialize for ExternalFoo {
 impl Deserialize for ExternalFoo {
     fn deserialize<R: BufRead + std::io::Seek>(raw: &mut Deserializer<R>) -> Result<Self, DeserializeError> {
         let len = raw.array()?;
-        let mut read_len = CBORReadLen::new(len);
+        let mut read_len = CBORReadLen::new(cbor_event::LenSz::Indefinite);
         read_len.read_elems(3)?;
         (|| -> Result<_, DeserializeError> {
             let index_0 = Ok(raw.unsigned_integer()? as u64)

--- a/tests/external_wasm_defs_multifile
+++ b/tests/external_wasm_defs_multifile
@@ -1,0 +1,50 @@
+#[derive(Clone, Debug)]
+#[wasm_bindgen]
+pub struct ExternalFoo(multi_chain_test::ExternalFoo);
+
+#[wasm_bindgen]
+impl ExternalFoo {
+    pub fn to_cbor_bytes(&self) -> Vec<u8> {
+        multi_chain_test::serialization::ToCBORBytes::to_cbor_bytes(&self.0)
+    }
+
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ExternalFoo, JsValue> {
+        multi_chain_test::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
+            .map(Self)
+            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+    }
+
+    pub fn index_0(&self) -> u64 {
+        self.0.index_0
+    }
+
+    pub fn index_1(&self) -> String {
+        self.0.index_1.clone()
+    }
+
+    pub fn index_2(&self) -> Vec<u8> {
+        self.0.index_2.clone()
+    }
+
+    pub fn new(index_0: u64, index_1: String, index_2: Vec<u8>) -> Self {
+        Self(multi_chain_test::ExternalFoo::new(index_0, index_1, index_2))
+    }
+}
+
+impl From<multi_chain_test::ExternalFoo> for ExternalFoo {
+    fn from(native: multi_chain_test::ExternalFoo) -> Self {
+        Self(native)
+    }
+}
+
+impl From<ExternalFoo> for multi_chain_test::ExternalFoo {
+    fn from(wasm: ExternalFoo) -> Self {
+        wasm.0
+    }
+}
+
+impl AsRef<multi_chain_test::ExternalFoo> for ExternalFoo {
+    fn as_ref(&self) -> &multi_chain_test::ExternalFoo {
+        &self.0
+    }
+}

--- a/tests/multifile/inputs/bar.cddl
+++ b/tests/multifile/inputs/bar.cddl
@@ -1,10 +1,10 @@
 bar = {
-	foo: #6.1337(foo),
+	foo: #6.1337([* foo]),
 	? derp: uint,
 	1 : uint / null,
 	? 5: text,
 	five: 5,
-	float: float64,
+	foo_map: { * foo => foo },
 }
 
 ; test refs too

--- a/tests/preserve-encodings/tests.rs
+++ b/tests/preserve-encodings/tests.rs
@@ -1,7 +1,7 @@
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cbor_event::StringLenSz;
+    use cbor_event::{Sz, StringLenSz};
 
     fn deser_test<T: Deserialize + ToCBORBytes>(orig: &T) {
         print_cbor_types("orig", &orig.to_cbor_bytes());


### PR DESCRIPTION
multi-file test updated to test json-gen output crate too

json-gen crate fixed to scope things in multiple files correctly

cbor_encodings imported per-type

removed some imports for consistency (e.g. most places used cbor_event::Special but some still used CBORSpecial. same with Sz and Type)

Includes refactoring/fixes for #137