### PR TITLE
C-style enum support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // Creating intermediate form from the CDDL
     for cddl_rule in dep_graph::topological_rule_order(&cddl_rules) {
-        println!("\n\n------------------------------------------\n- Handling rule: {scope}\n------------------------------------");
+        println!("\n\n------------------------------------------\n- Handling rule: {}:{}\n------------------------------------", scope, cddl_rule.name());
         parse_rule(&mut types, &pv, cddl_rule);
     }
     types.finalize(&pv);
@@ -124,7 +124,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("\n-----------------------------------------\n- Generating code...\n------------------------------------");
     let mut gen_scope = GenerationScope::new();
     gen_scope.generate(&types);
-    gen_scope.export()?;
+    gen_scope.export(&types)?;
     types.print_info();
 
     gen_scope.print_structs_without_deserialize();

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -32,7 +32,14 @@ table_arr_members = {
 	arr2: [*foo],
 }
 
+c_enum = 3 / 1 / 4
+
 type_choice = 0 / "hello world" / uint / text / bytes / #6.64([*uint])
+
+enums = [
+	c_enum,
+	type_choice,
+]
 
 group_choice = [ foo // 0, x: uint // plain ]
 
@@ -108,4 +115,3 @@ text_array_wrapper = [embedded_text]
 text_map_wrapper = { 721: embedded_text }
 
 inline_wrapper = [{ * text => text }]
-

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -101,6 +101,11 @@ mod tests {
     }
 
     #[test]
+    fn enums() {
+        let enums = Enums::new(CEnum::I3, TypeChoice::U64(53435364));
+    }
+
+    #[test]
     fn group_choice_foo() {
         deser_test(&GroupChoice::new_foo(0, String::new(), vec![]));
     }

--- a/tests/preserve-encodings/input.cddl
+++ b/tests/preserve-encodings/input.cddl
@@ -30,6 +30,13 @@ string_16_32 = #6.7(text .size (16..32))
 
 type_choice = 0 / "hello world" / uint / text / #6.16([*uint])
 
+c_enum = 3 / 1 / 4
+
+enums = [
+	c_enum,
+	type_choice,
+]
+
 plain = (d: #6.13(uint), e: tagged_text)
 
 group_choice = [ 3 // #6.10(2) // foo // 0, x: uint // plain ]

--- a/tests/preserve-encodings/tests.rs
+++ b/tests/preserve-encodings/tests.rs
@@ -367,6 +367,23 @@ mod tests {
     }
 
     #[test]
+    fn enums() {
+        let def_encodings = vec![Sz::Inline, Sz::One, Sz::Two, Sz::Four, Sz::Eight];
+        let enum_values = vec![3, 1, 4];
+        for def_enc in &def_encodings {
+            for enum_value in &enum_values {
+                let irregular_bytes = vec![
+                    arr_sz(2, *def_enc),
+                        // CEnum
+                        cbor_int(*enum_value, *def_enc),
+                        // TypeChoice
+                        cbor_int(0, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+            }
+        }
+    }
+
+    #[test]
     fn group_choice() {
         let def_encodings = vec![Sz::Inline, Sz::One, Sz::Two, Sz::Four, Sz::Eight];
         let str_6_encodings = vec![


### PR DESCRIPTION
Now something like:
```
redeemer_tag =
    0 ; @name Spend
  / 1 ; @name Mint
  / 2 ; @name Cert
  / 3 ; @name Reward
```

Will use C-style enums e.g.:
```
pub enum RedeemerTag {
    Spend,
    Mint,
    Cert,
    Reward,
}
```

vs 129 lines generated before (with preserve-encodings). It was less without preserve-encodings, but still ended up with `RedeemerTag` and `RedeemerTagKind` being effectively the exact same type.

This also improves usability as c-style enums can be directly exposed to WASM.

For preseve-encodings targets the encoding variables are pushed up to wherever they're used, similar to how primitives (uint, text, etc) are handled.