### PR TITLE
_CDDL_CODEGEN_RAW_BYTES_TYPE_ support

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -72,6 +72,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .collect::<Result<String, _>>()?;
     // we also need to mark the extern marker to a placeholder struct that won't get codegened
     input_files_content.push_str(&format!("{} = [0]", parsing::EXTERN_MARKER));
+    // and a raw bytes one too
+    input_files_content.push_str(&format!("{} = [1]", parsing::RAW_BYTES_MARKER));
 
     // Plain group / scope marking
     let cddl = cddl::parser::cddl_from_str(&input_files_content, true)?;

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -24,6 +24,7 @@ enum ControlOperator {
 
 pub const SCOPE_MARKER: &str = "_CDDL_CODEGEN_SCOPE_MARKER_";
 pub const EXTERN_MARKER: &str = "_CDDL_CODEGEN_EXTERN_TYPE_";
+pub const RAW_BYTES_MARKER: &str = "_CDDL_CODEGEN_RAW_BYTES_TYPE_";
 
 /// Some means it is a scope marker, containing the scope
 pub fn rule_is_scope_marker(cddl_rule: &cddl::ast::Rule) -> Option<String> {
@@ -58,7 +59,10 @@ pub fn parse_rule(
     match cddl_rule {
         cddl::ast::Rule::Type { rule, .. } => {
             let rust_ident = RustIdent::new(CDDLIdent::new(rule.name.to_string()));
-            if rule.name.to_string() == EXTERN_MARKER {
+            if matches!(
+                rule.name.to_string().as_str(),
+                EXTERN_MARKER | RAW_BYTES_MARKER
+            ) {
                 // ignore - this was inserted by us so that cddl's parsing succeeds
                 // see comments in main.rs
             } else {
@@ -430,6 +434,11 @@ fn parse_type(
                 types.register_rust_struct(
                     parent_visitor,
                     RustStruct::new_extern(type_name.clone()),
+                );
+            } else if ident.ident == RAW_BYTES_MARKER {
+                types.register_rust_struct(
+                    parent_visitor,
+                    RustStruct::new_raw_bytes(type_name.clone()),
                 );
             } else {
                 // Note: this handles bool constants too, since we apply the type aliases and they resolve


### PR DESCRIPTION
This is used for generating CML mostly as it lets us use existing structs, similar to `_CDDL_CODEGEN_EXTERN_`, but with the difference being that instead of simply calling the `Serialize`/`Deserialize` trait it instead treats it as if it's bytes by converting using CML's `RawBytesEncoding` trait. This is incredibly useful for crypto-related types (keys, hashes, etc) that don't store encoding details. Here, the encoding details are stored where they're used as if they were using `bytes` directly.