### PR TITLE
Always check read_len's remaining length in structs

### DIFF
--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -118,3 +118,15 @@ inline_wrapper = [{ * text => text }]
 
 top_level_array = [* uint]
 top_level_single_elem = [uint]
+
+overlapping_inlined = [
+	0 //
+	0, uint //
+	0, uint, text
+]
+
+overlapping0 = [0]
+overlapping1 = [0, uint]
+overlapping2 = [0, uint, text]
+
+overlapping = overlapping0 / overlapping1 / overlapping2

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -195,4 +195,25 @@ mod tests {
         arr2.index_0 *= arr2.index_0;
         assert_eq!(arr2.index_0, 81);
     }
+
+    #[test]
+    fn overlapping() {
+        let overlap0 = Overlapping::new_overlapping0(Overlapping0::new());
+        deser_test(&overlap0);
+        let overlap1 = Overlapping::new_overlapping1(Overlapping1::new(9));
+        deser_test(&overlap1);
+        let overlap2 = Overlapping::new_overlapping2(Overlapping2::new(5, "overlapping".into()));
+        deser_test(&overlap2);
+    }
+
+    #[test]
+    fn overlapping_inlined() {
+        // this test won't work until https://github.com/dcSpark/cddl-codegen/issues/175 is resolved.
+        let overlap0 = OverlappingInlined::new_i0();
+        deser_test(&overlap0);
+        let overlap1 = OverlappingInlined::new_overlapping_inlined1(9);
+        //deser_test(&overlap1);
+        let overlap2 = OverlappingInlined::new_overlapping_inlined2(5, "overlapping".into());
+        //deser_test(&overlap2);
+    }
 }


### PR DESCRIPTION
Fixes #171