### PR TITLE
Optional extern/raw-bytes read_len fix

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -2025,6 +2025,11 @@ impl GenerationScope {
                 .variant()
             {
                 RustStructType::CStyleEnum { variants } => {
+                    if config.optional_field {
+                        deser_code.content.line("read_len.read_elems(1)?;");
+                        deser_code.throws = true;
+                        deser_code.read_len_used = true;
+                    }
                     // if let Some(common) = enum_variants_common_constant_type(variants) {
                     //     // TODO: potentially simplified deserialization some day
                     //     // issue: https://github.com/dcSpark/cddl-codegen/issues/145
@@ -2059,6 +2064,11 @@ impl GenerationScope {
                     ));
                 }
                 RustStructType::RawBytesType => {
+                    if config.optional_field {
+                        deser_code.content.line("read_len.read_elems(1)?;");
+                        deser_code.throws = true;
+                        deser_code.read_len_used = true;
+                    }
                     let error_convert = ".map_err(Into::<DeserializeError>::into)";
                     if CLI_ARGS.preserve_encodings {
                         config

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -96,9 +96,10 @@ no_alias = [
 
 external_foo = _CDDL_CODEGEN_EXTERN_TYPE_
 
-externs = [
-	external_foo
-]
+externs = {
+    req: external_foo,
+  ? opt: external_foo,
+}
 
 ; types below test codegen_table_type
 

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -179,7 +179,10 @@ mod tests {
 
     #[test]
     fn externs() {
-        let externs = Externs::new(ExternalFoo::new(436, String::from("jfkdsjfd"), vec![1, 1, 1]));
+        let ext_foo = ExternalFoo::new(436, String::from("jfkdsjfd"), vec![1, 1, 1]);
+        let mut externs = Externs::new(ext_foo.clone());
+        deser_test(&externs);
+        externs.opt = Some(ext_foo);
         deser_test(&externs);
     }
 


### PR DESCRIPTION
Fixes #170

Other uses of `ConceptualRustType::Rust` don't appear to cause issues. The assumption about CBOR containing 1 element still holds in both (under the assumptions required for their format).