### PR TITLE
Extern macro CLI options for WASM boilerplate

### DIFF
--- a/docs/docs/command_line_flags.mdx
+++ b/docs/docs/command_line_flags.mdx
@@ -133,3 +133,46 @@ Generates a npm package.json along with build scripts (some of these scripts req
 cddl-codegen --input=example --output=export --package-json true --json-schema-export true
 ```
 :::
+
+<br/><br/>
+
+:::info `--common-import-override`
+Overrides the location of the static exports (e.g. error.rs, serialization.rs, etc).
+
+This is particularily useful for combining multiple crates each generated using cddl-codegen where they all share a shared core directory where the static files are located.
+
+**Default:** crate
+```bash
+cddl-codegen --input=example --output=export --common-import-override=cml_core
+```
+:::
+
+<br/><br/>
+
+:::info `--package-json`
+If it is passed in, it will call the supplied externally defined macro on each exported type, instead of manually exporting the functions for to/from CBOR bytes + to/from JSON API.
+
+The external macro is assumed to exist at the specified path and will be imported if there are module prefixes.
+
+The macro must take the wasm wrapper type as the only parameter.
+
+This macro will be called regardless of the values of to-from-bytes-methods / json-serde-derives / etc, so it is assumed that whatever logic your macros have is consistent with the other CLI flag values.
+
+```bash
+cddl-codegen --input=example --output=export --wasm-cbor-json-api-macro=cml_core_wasm::impl_wasm_cbor_json_api
+```
+:::
+
+<br/><br/>
+
+:::info `--wasm-conversion-macro`
+If it is passed in, it will call the supplied externally defined macro on each exported type, instead of manually exporting the rust <-> wasm conversion traits.
+
+The external macro is assumed to exist at the specified path and will be imported if there are module prefixes.
+
+The macro must take the rust type as the first parameter and the wasm wrapper type as the second one.
+
+```bash
+cddl-codegen --input=example --output=export --wasm-conversion-macro=cml_core_wasm::impl_wasm_conversions
+```
+:::

--- a/docs/docs/command_line_flags.mdx
+++ b/docs/docs/command_line_flags.mdx
@@ -166,7 +166,7 @@ cddl-codegen --input=example --output=export --wasm-cbor-json-api-macro=cml_core
 <br/><br/>
 
 :::info `--wasm-conversion-macro`
-If it is passed in, it will call the supplied externally defined macro on each exported type, instead of manually exporting the rust <-> wasm conversion traits.
+If it is passed in, it will call the supplied externally defined macro on each exported type, instead of manually exporting the rust/wasm conversion traits.
 
 The external macro is assumed to exist at the specified path and will be imported if there are module prefixes.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -74,6 +74,22 @@ pub struct Cli {
         default_value = "crate"
     )]
     pub common_import_override: String,
+
+    /// An external macro to be called instead of manually emitting functions for
+    /// conversions to/from CBOR bytes or JSON.
+    /// If the macro is scoped it will be imported using the supplied path.
+    /// e.g. foo::bar::qux will result in importing foo::bar::qux and then
+    /// calling qux!(A); for every struct A with a CBOR/JSON API
+    #[clap(long, value_parser)]
+    pub wasm_cbor_json_api_macro: Option<String>,
+
+    /// An external macro to be called instead of manually emitting traits for
+    /// WASM conversions to/from the inner rust type + AsRef.
+    /// If the macro is scoped it will be imported using the supplied path.
+    /// e.g. foo::bar::qux will result in importing foo::bar::qux and then
+    /// calling qux!(rust::path::A, A); for every struct A with a CBOR/JSON API
+    #[clap(long, value_parser)]
+    pub wasm_conversions_macro: Option<String>,
 }
 
 impl Cli {

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -3320,7 +3320,8 @@ impl<'a> WasmWrapper<'a> {
         // so we instead use the impl's macro spot to put them before the impl where we want them
         for (full_name, params) in self.macros {
             let macro_name = full_name.split("::").last().unwrap();
-            self.s_impl.r#macro(format!("{}!({});\n", macro_name, params.join(", ")));
+            self.s_impl
+                .r#macro(format!("{}!({});\n", macro_name, params.join(", ")));
         }
         self.s_impl.r#macro("#[wasm_bindgen]");
         gen_scope
@@ -3344,7 +3345,10 @@ impl<'a> WasmWrapper<'a> {
     fn add_conversion_methods(&mut self, native_name: &str, cli: &Cli) {
         match &cli.wasm_conversions_macro {
             Some(conversion_macro) => {
-                self.macros.push((conversion_macro.clone(), vec![native_name.to_owned(), self.ident.to_string()]));
+                self.macros.push((
+                    conversion_macro.clone(),
+                    vec![native_name.to_owned(), self.ident.to_string()],
+                ));
             }
             None => {
                 let mut from_wasm = codegen::Impl::new(self.ident.to_string());
@@ -3407,7 +3411,8 @@ fn create_base_wasm_struct<'a>(
                             "{}::serialization::Serialize::to_cbor_bytes(&self.0)",
                             cli.lib_name_code()
                         ));
-                        let mut to_canonical_bytes = codegen::Function::new("to_canonical_cbor_bytes");
+                        let mut to_canonical_bytes =
+                            codegen::Function::new("to_canonical_cbor_bytes");
                         to_canonical_bytes
                             .ret("Vec<u8>")
                             .arg_ref_self()


### PR DESCRIPTION
# Extern macro CLI option for WASM boilerplate

This will help compatibility for CML and make changing any details of
these only require changing those macros instead of needing to
regenerate the library again.

This also significantly decreases the amount of repetitive boilerplate
junk making reading the files clearer.

## --wasm-cbor-json-api-macro

Override for the CBOR to/from bytes API + to/from JSON

## --wasm-conversions-macro

Override for the conversion traits between wasm/rust types. (e.g. From
between them + AsRef for the rust one)