### PR TITLE
Full range check in rest of API

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -103,7 +103,7 @@ impl<'a> SerializeConfig<'a> {
     fn container_encoding_lookup(
         &self,
         prefix: &str,
-        encoding_fields: &Vec<EncodingField>,
+        encoding_fields: &[EncodingField],
         var: &str,
     ) -> String {
         let encoding_lookup = match &self.encoding_var_in_option_struct {

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -807,7 +807,7 @@ impl FixedValue {
     }
 }
 
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum Primitive {
     Bool,
     F64,
@@ -856,7 +856,7 @@ impl ToString for Primitive {
 }
 // TODO: impl display or fmt or whatever rust uses
 impl Primitive {
-    pub fn to_variant(&self) -> VariantIdent {
+    pub fn to_variant(self) -> VariantIdent {
         VariantIdent::new_custom(match self {
             Primitive::Bool => "Bool",
             Primitive::F32 => "F32",
@@ -1341,6 +1341,14 @@ impl RustType {
                 }
             },
         }
+    }
+
+    pub fn needs_bounds_check_if_inlined(&self, types: &IntermediateTypes) -> bool {
+        self.config.bounds.is_some()
+            || match self.resolve_alias_shallow() {
+                ConceptualRustType::Rust(ident) => types.can_new_fail(ident),
+                _ => false,
+            }
     }
 
     fn _cbor_special_type(&self) -> Option<CBORSpecial> {

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -136,7 +136,7 @@ fn parse_type_choices(
     types: &mut IntermediateTypes,
     parent_visitor: &ParentVisitor,
     name: &RustIdent,
-    type_choices: &Vec<TypeChoice>,
+    type_choices: &[TypeChoice],
     tag: Option<usize>,
     generic_params: Option<Vec<RustIdent>>,
     cli: &Cli,

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -160,3 +160,15 @@ bounds = [
     a: [* uint] .size (1..3),
     b: { * uint => uint } .le 3
 ]
+
+bounds_type_choice = bytes .size (0..64)
+                   / text .size (0..64)
+
+bounds_group_choice = [
+    ; @name a
+    a: uint, b: text .le 4 //
+    ; @name b
+    hash //
+    ; @name c
+    1, x: hash, y: hash
+]

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -301,7 +301,7 @@ mod tests {
 
     #[test]
     fn bounds() {
-        deser_test(&Bounds::new(10, 5, 3, "abc".to_owned(), vec![5], [(0, 1), (2, 3)].into()));
+        deser_test(&Bounds::new(10, 5, 4, "abc".to_owned(), vec![5], [(0, 1), (2, 3)].into()).unwrap());
         enum OOB {
             Below,
             Lower,
@@ -373,6 +373,13 @@ mod tests {
         assert!(make_bounds(OOB::Lower, OOB::Upper, OOB::Lower, OOB::Upper, OOB::Above, OOB::Upper).is_err());
         // b oob
         assert!(make_bounds(OOB::Lower, OOB::Upper, OOB::Lower, OOB::Upper, OOB::Upper, OOB::Above).is_err());
+
+        // type and group choices share the same deserialization code so we only check the API
+        assert!(BoundsTypeChoice::new_bytes(vec![0; 64]).is_ok());
+        assert!(BoundsTypeChoice::new_bytes(vec![0; 65]).is_err());
+        assert!(BoundsGroupChoice::new_a(0, "four".to_owned()).is_ok());
+        assert!(BoundsGroupChoice::new_a(0, "hello".to_owned()).is_err());
+        deser_test(&BoundsGroupChoice::new_c(Hash::new(vec![]).unwrap(), Hash::new(vec![]).unwrap()));
     }
 
     #[test]

--- a/tests/external_wasm_defs
+++ b/tests/external_wasm_defs
@@ -8,10 +8,10 @@ impl ExternalFoo {
         cddl_lib::serialization::ToCBORBytes::to_cbor_bytes(&self.0)
     }
 
-    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ExternalFoo, JsValue> {
+    pub fn from_cbor_bytes(cbor_bytes: &[u8]) -> Result<ExternalFoo, JsError> {
         cddl_lib::serialization::Deserialize::from_cbor_bytes(cbor_bytes)
             .map(Self)
-            .map_err(|e| JsValue::from_str(&format!("from_bytes: {}", e)))
+            .map_err(Into::into)
     }
 
     pub fn index_0(&self) -> u64 {

--- a/tests/preserve-encodings/input.cddl
+++ b/tests/preserve-encodings/input.cddl
@@ -90,6 +90,8 @@ array_opt_fields = [
 ;  ? z: null,
 ]
 
+hash = bytes .size (0..8)
+
 bounds = [
     w: -1000 .. 1000
     x: uint .le 7,
@@ -97,4 +99,16 @@ bounds = [
     z: text .size (3..14),
     a: [* uint] .size (1..3),
     b: { * uint => uint } .le 3
+]
+
+bounds_type_choice = bytes .size (0..64)
+                   / text .size (0..64)
+
+bounds_group_choice = [
+    ; @name a
+    a: uint, b: text .le 4 //
+    ; @name b
+    hash //
+    ; @name c
+    1, x: hash, y: hash
 ]

--- a/tests/preserve-encodings/tests.rs
+++ b/tests/preserve-encodings/tests.rs
@@ -791,6 +791,13 @@ mod tests {
         assert!(make_bounds(OOB::Lower, OOB::Upper, OOB::Lower, OOB::Upper, OOB::Above, OOB::Upper).is_err());
         // b oob
         assert!(make_bounds(OOB::Lower, OOB::Upper, OOB::Lower, OOB::Upper, OOB::Upper, OOB::Above).is_err());
+
+        // type and group choices share the same deserialization code so we only check the API
+        assert!(BoundsTypeChoice::new_bytes(vec![0; 64]).is_ok());
+        assert!(BoundsTypeChoice::new_bytes(vec![0; 65]).is_err());
+        assert!(BoundsGroupChoice::new_a(0, "four".to_owned()).is_ok());
+        assert!(BoundsGroupChoice::new_a(0, "hello".to_owned()).is_err());
+        deser_test(&BoundsGroupChoice::new_c(Hash::new(vec![]).unwrap(), Hash::new(vec![]).unwrap()));
     }
 
     #[test]


### PR DESCRIPTION
Check ranges and error on incorrect ones in constructors and setters in all spots.

Additional non-deserialization test checks to check the above.

Migrate few remaining usage of `JsValue` for WASM errors away to `JsError` to be consistent with the rest of the generated code.