### PR TITLE
Enum length-check fixes + Enum optional field support

### DIFF
--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -181,13 +181,13 @@ enum_opt_embed_fields = [
   ; @name ec
   1, uint, 7 //
 ; doesn't parse but would result in triple nesting so worth testing if we can ever parse it
-;  1, ? (text / null), 9
+;  1, ? (text / null), #6.9(9)
   ; @name ed
   1, uint, ?text //
   ; @name ee
   1, uint, ?bytes, uint //
   ; @name ef
-  1, ? non_overlapping_type_choice_some, 11 //
+  1, ? non_overlapping_type_choice_some, #6.11(11) //
   ; @name eg
-  1, ? overlapping_inlined, 13
+  1, ? overlapping_inlined, #6.13(13)
 ]

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -172,3 +172,22 @@ bounds_group_choice = [
     ; @name c
     1, x: hash, y: hash
 ]
+
+enum_opt_embed_fields = [
+  ; @name ea
+  1 //
+  ; @name eb
+  1, ?text, 5 //
+  ; @name ec
+  1, uint, 7 //
+; doesn't parse but would result in triple nesting so worth testing if we can ever parse it
+;  1, ? (text / null), 9
+  ; @name ed
+  1, uint, ?text //
+  ; @name ee
+  1, uint, ?bytes, uint //
+  ; @name ef
+  1, ? non_overlapping_type_choice_some, 11 //
+  ; @name eg
+  1, ? overlapping_inlined, 13
+]

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -215,13 +215,12 @@ mod tests {
 
     #[test]
     fn overlapping_inlined() {
-        // this test won't work until https://github.com/dcSpark/cddl-codegen/issues/175 is resolved.
         let overlap0 = OverlappingInlined::new_one();
         deser_test(&overlap0);
         let overlap1 = OverlappingInlined::new_two(9);
-        //deser_test(&overlap1);
+        deser_test(&overlap1);
         let overlap2 = OverlappingInlined::new_three(5, "overlapping".into());
-        //deser_test(&overlap2);
+        deser_test(&overlap2);
     }
 
     #[test]
@@ -391,5 +390,41 @@ mod tests {
         set_type_choice.insert(TypeChoice::Helloworld);
         let mut set_group_choice: std::collections::BTreeSet<GroupChoice> = std::collections::BTreeSet::new();
         set_group_choice.insert(GroupChoice::GroupChoice1(37));
+    }
+
+    #[test]
+    fn enum_opt_embed_fields() {
+        let a = EnumOptEmbedFields::new_ea();
+        deser_test(&a);
+        let b1 = EnumOptEmbedFields::new_eb(Some("Hello".to_owned()));
+        deser_test(&b1);
+        let b2 = EnumOptEmbedFields::new_eb(None);
+        deser_test(&b2);
+        let c = EnumOptEmbedFields::new_ec(100);
+        deser_test(&c);
+        let mut d1 = EnumOptEmbedFields::new_ed(1);
+        match &mut d1 {
+            EnumOptEmbedFields::Ed(ed) => ed.index_2 = Some("Goodbye".to_owned()),
+            _ => panic!(),
+        }
+        deser_test(&d1);
+        let d2 = EnumOptEmbedFields::new_ed(2);
+        deser_test(&d2);
+        let mut e1 = EnumOptEmbedFields::new_ee(0, 0);
+        match &mut e1 {
+            EnumOptEmbedFields::Ee(ee) => ee.index_2 = Some(vec![0xBA, 0xAD, 0xF0, 0x0D]),
+            _ => panic!(),
+        }
+        deser_test(&e1);
+        let e2 = EnumOptEmbedFields::new_ee(u64::MAX, u64::MAX);
+        deser_test(&e2);
+        let f1 = EnumOptEmbedFields::new_ef(Some(NonOverlappingTypeChoiceSome::U64(5)));
+        deser_test(&f1);
+        let f2 = EnumOptEmbedFields::new_ef(None);
+        deser_test(&f2);
+        let g1 = EnumOptEmbedFields::new_eg(Some(OverlappingInlined::new_two(0)));
+        deser_test(&g1);
+        let g2 = EnumOptEmbedFields::new_eg(None);
+        deser_test(&g2);
     }
 }

--- a/tests/preserve-encodings/input.cddl
+++ b/tests/preserve-encodings/input.cddl
@@ -113,7 +113,6 @@ bounds_group_choice = [
     1, x: hash, y: hash
 ]
 
-; just testing this compiles (for now? possibly have full tests in a later commit)
 overlapping_inlined = [
     ; @name one
     0 //
@@ -131,13 +130,13 @@ enum_opt_embed_fields = [
     ; @name ec
     1, uint, 7 //
 ; doesn't parse but would result in triple nesting so worth testing if we can ever parse it
-;  1, ? (text / null), 9
+;  1, ? (text / null), #6.9(9)
     ; @name ed
     1, uint, ?text //
     ; @name ee
-   1, uint, ?bytes, uint //
+    1, uint, ?bytes, uint //
     ;  @name ef
-    1, ? non_overlapping_type_choice_some, 11 //
+    1, ? non_overlapping_type_choice_some, #6.11(11) //
     ; @name eg
-    1, ? overlapping_inlined, 13
+    1, ? overlapping_inlined, #6.13(13)
 ]

--- a/tests/preserve-encodings/input.cddl
+++ b/tests/preserve-encodings/input.cddl
@@ -112,3 +112,32 @@ bounds_group_choice = [
     ; @name c
     1, x: hash, y: hash
 ]
+
+; just testing this compiles (for now? possibly have full tests in a later commit)
+overlapping_inlined = [
+    ; @name one
+    0 //
+    ; @name two
+    0, uint //
+    ; @name three
+    0, uint, text
+]
+
+enum_opt_embed_fields = [
+    ; @name ea
+    1 //
+    ; @name eb
+    1, ?text, 5 //
+    ; @name ec
+    1, uint, 7 //
+; doesn't parse but would result in triple nesting so worth testing if we can ever parse it
+;  1, ? (text / null), 9
+    ; @name ed
+    1, uint, ?text //
+    ; @name ee
+   1, uint, ?bytes, uint //
+    ;  @name ef
+    1, ? non_overlapping_type_choice_some, 11 //
+    ; @name eg
+    1, ? overlapping_inlined, 13
+]


### PR DESCRIPTION
Fixes #175

Now properly checks all lengths for all variants to ensure that overlapping types parse the correct variant instead of prematurely thinking it's a subset of one.

Also fixes having CBORReadLen contributions from previous variants that tried to parse from contributing to later variant parses (possibly causing issues if it meant it already hit the limit).

Includes support for optional fields within enums that get inlined.

Tests for both cases.