### PR TITLE
More test cases for plain groups

### DIFF
--- a/static/serialization_preserve.rs
+++ b/static/serialization_preserve.rs
@@ -11,6 +11,10 @@ impl CBORReadLen {
         }
     }
 
+    pub fn read(&self) -> u64 {
+        self.read
+    }
+
     // Marks {n} values as being read, and if we go past the available definite length
     // given by the CBOR, we return an error.
     pub fn read_elems(&mut self, count: usize) -> Result<(), DeserializeFailure> {

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -20,9 +20,9 @@ bar = {
 plain = (d: #6.23(uint), e: tagged_text)
 outer = [a: uint, b: plain, c: "some text"] ; @used_as_key
 plain_arrays = [
-; this is not supported right now. When single-element arrays are supported remove this.
-;	single: [plain],
-	multi: [*plain],
+    embedded: plain,
+    single: [plain],
+    multi: [*plain],
 ]
 
 table = { * uint => text }

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -53,7 +53,40 @@ mod tests {
     #[test]
     fn plain_arrays() {
         let plain = Plain::new(7576, String::from("wiorurri34h").into());
-        deser_test(&PlainArrays::new(vec![plain.clone(), plain.clone()]));
+        let plain_arrays = PlainArrays::new(
+            plain.clone(),
+            plain.clone(),
+            vec![plain.clone(), plain.clone()]
+        );
+        deser_test(&plain_arrays);
+        // need to make sure they are actually inlined!
+        let bytes = vec![
+            arr_def(4),
+                // embedded
+                cbor_tag(23),
+                    cbor_int(7576, cbor_event::Sz::Two),
+                cbor_tag_sz(42, cbor_event::Sz::One),
+                    cbor_string("wiorurri34h"),
+                // single
+                arr_def(2),
+                    cbor_tag(23),
+                        cbor_int(7576, cbor_event::Sz::Two),
+                    cbor_tag_sz(42, cbor_event::Sz::One),
+                        cbor_string("wiorurri34h"),
+                // multiple
+                arr_def(4),
+                    cbor_tag(23),
+                        cbor_int(7576, cbor_event::Sz::Two),
+                    cbor_tag_sz(42, cbor_event::Sz::One),
+                        cbor_string("wiorurri34h"),
+                    cbor_tag(23),
+                        cbor_int(7576, cbor_event::Sz::Two),
+                    cbor_tag_sz(42, cbor_event::Sz::One),
+                        cbor_string("wiorurri34h"),
+        ].into_iter().flatten().clone().collect::<Vec<u8>>();
+        let from_bytes = PlainArrays::from_cbor_bytes(&bytes).unwrap();
+        assert_eq!(from_bytes.to_cbor_bytes(), bytes);
+        assert_eq!(plain_arrays.to_cbor_bytes(), bytes);
     }
 
     #[test]

--- a/tests/deser_test
+++ b/tests/deser_test
@@ -35,7 +35,7 @@ fn cbor_string(s: &str) -> Vec<u8> {
 }
 
 fn cbor_tag(t: u8) -> Vec<u8> {
-    assert!(t <= 0xd4 - 0xc0);
+    assert!(t <= 0xd7 - 0xc0);
     vec![0xc0u8 + t]
 }
 

--- a/tests/preserve-encodings/input.cddl
+++ b/tests/preserve-encodings/input.cddl
@@ -43,6 +43,12 @@ enums = [
 
 plain = (d: #6.13(uint), e: tagged_text)
 
+plain_arrays = [
+    embedded: plain,
+    single: [plain],
+    multi: [*plain],
+]
+
 group_choice = [ 3 // #6.10(2) // foo // 0, x: uint // plain ]
 
 foo_bytes = bytes .cbor foo


### PR DESCRIPTION
Specifically tests for support for #121 for plain groups.

For multi arrays covered by #120
For single ones covered by #210

We are keeping #121 open for now as the case for single non-plain-groups e.g. `[uint]` is not covered. We've yet to see this used anywhere in Cardano so it's low priority to fix.