### PR TITLE
Avoid clippy warning in enum deserialization  generated code

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -2284,9 +2284,7 @@ impl GenerationScope {
                                 };
                                 type_check.line(format!(
                                     "_ => {}.negative_integer_sz(){}.map(|(x, _enc)| x)? as {},",
-                                    deserializer_name,
-                                    bounds_fn,
-                                    p
+                                    deserializer_name, bounds_fn, p
                                 ));
                             } else {
                                 type_check.line(format!(

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -2194,7 +2194,7 @@ impl GenerationScope {
                                 deserializer_name,
                                 func,
                                 non_preserve_bounds_fn(x, &type_cfg.bounds),
-                                p.to_string(),
+                                p,
                                 before_after.after_str(false)
                             ));
                             deser_code.throws = true;
@@ -2208,7 +2208,7 @@ impl GenerationScope {
                         config.final_exprs,
                         "unsigned_integer",
                         "x",
-                        &format!("x as {}", p.to_string()),
+                        &format!("x as {}", p),
                     ),
                     Primitive::U64 => {
                         deser_primitive(config.final_exprs, "unsigned_integer", "x", "x")
@@ -2247,7 +2247,7 @@ impl GenerationScope {
                                 deserializer_name,
                                 bounds_fn(&positive_bounds)
                             ))
-                            .line(format!("(x as {}, Some(enc))", p.to_string()))
+                            .line(format!("(x as {}, Some(enc))", p))
                             .after(",");
                             type_check.push_block(pos);
                             // let this cover both the negative int case + error case
@@ -2257,7 +2257,7 @@ impl GenerationScope {
                                 deserializer_name,
                                 bounds_fn(&negative_bounds)
                             ))
-                            .line(format!("(x as {}, Some(enc))", p.to_string()))
+                            .line(format!("(x as {}, Some(enc))", p))
                             .after(",");
                             type_check.push_block(neg);
                         } else {
@@ -2266,7 +2266,7 @@ impl GenerationScope {
                                     "cbor_event::Type::UnsignedInteger => {}.unsigned_integer(){}? as {},",
                                     deserializer_name,
                                     non_preserve_bounds_fn("x", &positive_bounds),
-                                    p.to_string()));
+                                    p));
                             // https://github.com/primetype/cbor_event/issues/9
                             // cbor_event's negative_integer() doesn't support i64::MIN so we use the _sz function here instead as that one supports all nints
                             if *p == Primitive::I64 {
@@ -2286,14 +2286,14 @@ impl GenerationScope {
                                     "_ => {}.negative_integer_sz(){}.map(|(x, _enc)| x)? as {},",
                                     deserializer_name,
                                     bounds_fn,
-                                    p.to_string()
+                                    p
                                 ));
                             } else {
                                 type_check.line(format!(
                                     "_ => {}.negative_integer(){}? as {},",
                                     deserializer_name,
                                     non_preserve_bounds_fn("x", &negative_bounds),
-                                    p.to_string()
+                                    p
                                 ));
                             }
                         }

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -6401,18 +6401,17 @@ fn make_enum_variant_return_if_deserialized(
             deser_body.line(&format!(
                 "let deser_variant: Result<_, DeserializeError> = {single_line};"
             ));
-            Block::new("match deser_variant")
         }
         _ => {
-            let mut variant_deser =
-                Block::new("match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError>");
-            variant_deser.after(")(raw)");
+            let mut variant_deser = Block::new(
+                "let deser_variant = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError>",
+            );
+            variant_deser.after(")(raw);");
             variant_deser.push_all(variant_deser_code.content);
             deser_body.push_block(variant_deser);
-            // can't chain blocks so we just put them one after the other
-            Block::new("")
         }
     }
+    Block::new("match deser_variant")
 }
 
 fn surround_in_len_checks(
@@ -6996,13 +6995,13 @@ fn generate_enum(
                             cli,
                         );
                         let mut variant_deser = Block::new(
-                            "match (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError>",
+                            "let variant_deser = (|raw: &mut Deserializer<_>| -> Result<_, DeserializeError>",
                         );
-                        variant_deser.after(")(raw)");
+                        variant_deser.after(")(raw);");
                         variant_deser.push_all(variant_deser_code.content);
                         deser_body.push_block(variant_deser);
                         // can't chain blocks so we just put them one after the other
-                        let mut return_if_deserialized = Block::new("");
+                        let mut return_if_deserialized = Block::new("match variant_deser");
                         return_if_deserialized.line("Ok(variant) => return Ok(variant),");
                         return_if_deserialized
                     }

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -835,9 +835,9 @@ pub enum Primitive {
     Bytes,
 }
 
-impl ToString for Primitive {
-    fn to_string(&self) -> String {
-        String::from(match self {
+impl std::fmt::Display for Primitive {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
             Primitive::Bool => "bool",
             Primitive::F32 => "f32",
             Primitive::F64 => "f64",

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -837,22 +837,26 @@ pub enum Primitive {
 
 impl std::fmt::Display for Primitive {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", match self {
-            Primitive::Bool => "bool",
-            Primitive::F32 => "f32",
-            Primitive::F64 => "f64",
-            Primitive::U8 => "u8",
-            Primitive::I8 => "i8",
-            Primitive::U16 => "u16",
-            Primitive::I16 => "i16",
-            Primitive::U32 => "u32",
-            Primitive::I32 => "i32",
-            Primitive::U64 => "u64",
-            Primitive::I64 => "i64",
-            Primitive::N64 => "u64",
-            Primitive::Str => "String",
-            Primitive::Bytes => "Vec<u8>",
-        })
+        write!(
+            f,
+            "{}",
+            match self {
+                Primitive::Bool => "bool",
+                Primitive::F32 => "f32",
+                Primitive::F64 => "f64",
+                Primitive::U8 => "u8",
+                Primitive::I8 => "i8",
+                Primitive::U16 => "u16",
+                Primitive::I16 => "i16",
+                Primitive::U32 => "u32",
+                Primitive::I32 => "i32",
+                Primitive::U64 => "u64",
+                Primitive::I64 => "i64",
+                Primitive::N64 => "u64",
+                Primitive::Str => "String",
+                Primitive::Bytes => "Vec<u8>",
+            }
+        )
     }
 }
 // TODO: impl display or fmt or whatever rust uses


### PR DESCRIPTION
This is a new clippy warning that was just added and is now causing CML CI to trip up.