### PR TITLE
Extern generics

### DIFF
--- a/docs/docs/comment_dsl.mdx
+++ b/docs/docs/comment_dsl.mdx
@@ -119,6 +119,7 @@ This can also be useful when you have a spec that is either very awkward to use 
 
 This can also be useful when you have a spec that is either very awkward to use (so you hand-write or hand-modify after generation) in some type so you don't generate those types and instead manually merge those hand-written/hand-modified structs back in to the code afterwards. This saves you from having to manually remove all code that is generated regarding `Foo` first before merging in your own.
 
+This also works with generics e.g. you can refer to `foo<T>`. As with other generics this will create a `pub type FooT = Foo<T>;` definition in rust to work with wasm-bindgen's restrictions (no generics) as on the wasm side there will be references to a `FooT` in wasm. The wasm type definition is not emitted as that will be implementation-dependent. For an example see `extern_generic` in the `core` unit test.
 
 ## _CDDL_CODEGEN_RAW_BYTES_TYPE_
 

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -108,7 +108,7 @@ externs = {
 extern_generic = _CDDL_CODEGEN_EXTERN_TYPE_
 
 using_extern_generic = [
-  foo: extern_generic<foo>,
+  foo: extern_generic<external_foo>,
 ]
 
 ; types below test codegen_table_type

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -105,6 +105,12 @@ externs = {
   ? opt: external_foo,
 }
 
+extern_generic = _CDDL_CODEGEN_EXTERN_TYPE_
+
+using_extern_generic = [
+  foo: extern_generic<foo>,
+]
+
 ; types below test codegen_table_type
 
 standalone_table = { * uint => text }

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -226,7 +226,7 @@ mod tests {
     #[test]
     fn externs_generic() {
         deser_test(&UsingExternGeneric::new(
-            ExternGeneric::new(Foo::new(u64::MAX, String::from("asdfghjkl"), vec![0])),
+            ExternGeneric::new(ExternalFoo::new(u64::MAX, String::from("asdfghjkl"), vec![0])),
         ));
     }
 

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -224,6 +224,13 @@ mod tests {
     }
 
     #[test]
+    fn externs_generic() {
+        deser_test(&UsingExternGeneric::new(
+            ExternGeneric::new(Foo::new(u64::MAX, String::from("asdfghjkl"), vec![0])),
+        ));
+    }
+
+    #[test]
     fn top_level_arrays() {
         // this part of the test just tests that the resulting code compiles
         // e.g. the presence of the typedef instead of a new array struct by being able to asign to it.

--- a/tests/external_rust_defs
+++ b/tests/external_rust_defs
@@ -56,3 +56,28 @@ impl serialization::Deserialize for ExternalFoo {
         .map_err(|e| e.annotate("ExternalFoo"))
     }
 }
+
+#[derive(Clone, Debug)]
+pub struct ExternGeneric<T>(pub T);
+
+impl<T> ExternGeneric<T> {
+    pub fn new(x: T) -> Self {
+        Self(x)
+    }
+}
+
+impl<T: cbor_event::se::Serialize> cbor_event::se::Serialize for ExternGeneric<T> {
+    fn serialize<'se, W: std::io::Write>(
+        &self,
+        serializer: &'se mut cbor_event::se::Serializer<W>,
+    ) -> cbor_event::Result<&'se mut cbor_event::se::Serializer<W>> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<T: serialization::Deserialize> serialization::Deserialize for ExternGeneric<T> {
+    fn deserialize<R: std::io::BufRead + std::io::Seek>(raw: &mut cbor_event::de::Deserializer<R>) -> Result<Self, error::DeserializeError> {
+        T::deserialize(raw).map(Self)
+    }
+}
+

--- a/tests/external_rust_defs_compiles_with_json_preserve
+++ b/tests/external_rust_defs_compiles_with_json_preserve
@@ -59,3 +59,27 @@ impl serialization::Deserialize for ExternalFoo {
         .map_err(|e| e.annotate("ExternalFoo"))
     }
 }
+
+#[derive(Clone, Debug)]
+pub struct ExternGeneric<T>(pub T);
+
+impl<T> ExternGeneric<T> {
+    pub fn new(x: T) -> Self {
+        Self(x)
+    }
+}
+
+impl<T: cbor_event::se::Serialize> cbor_event::se::Serialize for ExternGeneric<T> {
+    fn serialize<'se, W: std::io::Write>(
+        &self,
+        serializer: &'se mut cbor_event::se::Serializer<W>,
+    ) -> cbor_event::Result<&'se mut cbor_event::se::Serializer<W>> {
+        self.0.serialize(serializer)
+    }
+}
+
+impl<T: serialization::Deserialize> serialization::Deserialize for ExternGeneric<T> {
+    fn deserialize<R: std::io::BufRead + std::io::Seek>(raw: &mut cbor_event::de::Deserializer<R>) -> Result<Self, error::DeserializeError> {
+        T::deserialize(raw).map(Self)
+    }
+}

--- a/tests/external_wasm_defs
+++ b/tests/external_wasm_defs
@@ -49,16 +49,16 @@ impl AsRef<cddl_lib::ExternalFoo> for ExternalFoo {
     }
 }
 
-type ExternGenericFoo = Foo;
+type ExternGenericExternalFoo = ExternalFoo;
 
-impl From<cddl_lib::ExternGeneric<cddl_lib::Foo>> for Foo {
-    fn from(native: cddl_lib::ExternGeneric<cddl_lib::Foo>) -> Self {
+impl From<cddl_lib::ExternGeneric<cddl_lib::ExternalFoo>> for ExternalFoo {
+    fn from(native: cddl_lib::ExternGeneric<cddl_lib::ExternalFoo>) -> Self {
         native.0.into()
     }
 }
 
-impl From<Foo> for cddl_lib::ExternGeneric<cddl_lib::Foo> {
-    fn from(wasm: Foo) -> Self {
+impl From<ExternalFoo> for cddl_lib::ExternGeneric<cddl_lib::ExternalFoo> {
+    fn from(wasm: ExternalFoo) -> Self {
         cddl_lib::ExternGeneric::new(wasm.0)
     }
 }

--- a/tests/external_wasm_defs
+++ b/tests/external_wasm_defs
@@ -48,3 +48,17 @@ impl AsRef<cddl_lib::ExternalFoo> for ExternalFoo {
         &self.0
     }
 }
+
+type ExternGenericFoo = Foo;
+
+impl From<cddl_lib::ExternGeneric<cddl_lib::Foo>> for Foo {
+    fn from(native: cddl_lib::ExternGeneric<cddl_lib::Foo>) -> Self {
+        native.0.into()
+    }
+}
+
+impl From<Foo> for cddl_lib::ExternGeneric<cddl_lib::Foo> {
+    fn from(wasm: Foo) -> Self {
+        cddl_lib::ExternGeneric::new(wasm.0)
+    }
+}


### PR DESCRIPTION
Allows types defined by `_CDDL_CODEGEN_EXTERN_TYPE_` to be used with generic arguments.

Generics will be used directly on the rust side, but due to wasm-bindgen restrictions must be specified for each concrete type like with current generic support.