### PR TITLE
Fix issue with overlapping inlined basic embedded enums

### DIFF
--- a/src/generation.rs
+++ b/src/generation.rs
@@ -6555,7 +6555,7 @@ fn generate_enum(
         let mut first_types = BTreeSet::new();
         let mut duplicates = false;
         for variant in variants.iter() {
-            for first_type in variant.cbor_types(types) {
+            for first_type in variant.cbor_types_inner(types, rep) {
                 // to_byte(0) is used since cbor_event::Type doesn't implement
                 // Ord or Hash so we can't put it in a set. Since we fix the lenth
                 // to always 0 this still remains a 1-to-1 mapping to Type.
@@ -6923,7 +6923,7 @@ fn generate_enum(
                     ),
                 };
                 let cbor_types_str = variant
-                    .cbor_types(types)
+                    .cbor_types_inner(types, rep)
                     .into_iter()
                     .map(cbor_type_code_str)
                     .collect::<Vec<_>>()

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -6552,22 +6552,30 @@ fn generate_enum(
     // We avoid checking ALL variants if we can figure it out by instead checking the type.
     // This only works when the variants don't have first types in common.
     let mut non_overlapping_types_match = {
-        let mut first_types = BTreeSet::new();
-        let mut duplicates = false;
+        let mut all_first_types = BTreeSet::new();
+        let mut duplicates_or_unknown = false;
         for variant in variants.iter() {
-            for first_type in variant.cbor_types_inner(types, rep) {
-                // to_byte(0) is used since cbor_event::Type doesn't implement
-                // Ord or Hash so we can't put it in a set. Since we fix the lenth
-                // to always 0 this still remains a 1-to-1 mapping to Type.
-                if !first_types.insert(first_type.to_byte(0)) {
-                    duplicates = true;
+            match variant.cbor_types_inner(types, rep) {
+                Some(first_types) => {
+                    for first_type in first_types.iter() {
+                        // to_byte(0) is used since cbor_event::Type doesn't implement
+                        // Ord or Hash so we can't put it in a set. Since we fix the lenth
+                        // to always 0 this still remains a 1-to-1 mapping to Type.
+                        if !all_first_types.insert(first_type.to_byte(0)) {
+                            duplicates_or_unknown = true;
+                        }
+                    }
+                }
+                None => {
+                    duplicates_or_unknown = true;
+                    break;
                 }
             }
         }
-        if duplicates {
+        if duplicates_or_unknown {
             None
         } else {
-            let deser_covers_all_types = first_types.len() == 8;
+            let deser_covers_all_types = all_first_types.len() == 8;
             Some((Block::new("match raw.cbor_type()?"), deser_covers_all_types))
         }
     };
@@ -6869,12 +6877,22 @@ fn generate_enum(
                         } else {
                             variant.name_as_var()
                         };
-                        let (before, after) =
-                            if cli.preserve_encodings || !variant.rust_type().is_fixed_value() {
-                                (Cow::from(format!("let {var_names_str} = ")), ";")
-                            } else {
-                                (Cow::from(""), "")
+                        // also used to check if it's a basic rust group
+                        let basic_rust_group_def_len =
+                            match ty.conceptual_type.resolve_alias_shallow() {
+                                ConceptualRustType::Rust(ident) if types.is_plain_group(ident) => {
+                                    Some(types.rust_struct(ident).unwrap().cbor_len_info(types))
+                                }
+                                _ => None,
                             };
+                        let (before, after) = if cli.preserve_encodings
+                            || !variant.rust_type().is_fixed_value()
+                            || basic_rust_group_def_len.is_some()
+                        {
+                            (Cow::from(format!("let {var_names_str} = ")), ";")
+                        } else {
+                            (Cow::from(""), "")
+                        };
                         let mut variant_deser_code = gen_scope.generate_deserialize(
                             types,
                             (variant.rust_type()).into(),
@@ -6883,34 +6901,49 @@ fn generate_enum(
                             cli,
                         );
                         let names_without_outer = enum_gen_info.names_without_outer();
-                        // we can avoid this ugly block and directly do it as a line possibly
-                        if variant_deser_code.content.as_single_line().is_some()
-                            && names_without_outer.len() == 1
-                        {
-                            variant_deser_code = gen_scope.generate_deserialize(
-                                types,
-                                (variant.rust_type()).into(),
-                                DeserializeBeforeAfter::new(
-                                    &format!("Ok({}::{}(", name, variant.name),
-                                    "))",
-                                    false,
-                                ),
-                                DeserializeConfig::new(&variant.name_as_var()),
+                        if let Some(len_info) = basic_rust_group_def_len {
+                            // this will never be 1 line to don't bother with the below cases
+                            variant_deser_code = surround_in_len_checks(
+                                variant_deser_code,
+                                len_info,
+                                rep.unwrap(),
                                 cli,
                             );
-                        } else if names_without_outer.is_empty() {
+                            variant_deser_code.content.line(&format!(
+                                "Ok({}::{}({}))",
+                                name, variant.name, var_names_str
+                            ));
                             variant_deser_code
-                                .content
-                                .line(&format!("Ok({}::{})", name, variant.name));
                         } else {
-                            enum_gen_info.generate_constructor(
-                                &mut variant_deser_code.content,
-                                "Ok(",
-                                ")",
-                                None,
-                            );
+                            // we can avoid this ugly block and directly do it as a line possibly
+                            if variant_deser_code.content.as_single_line().is_some()
+                                && names_without_outer.len() == 1
+                            {
+                                variant_deser_code = gen_scope.generate_deserialize(
+                                    types,
+                                    (variant.rust_type()).into(),
+                                    DeserializeBeforeAfter::new(
+                                        &format!("Ok({}::{}(", name, variant.name),
+                                        "))",
+                                        false,
+                                    ),
+                                    DeserializeConfig::new(&variant.name_as_var()),
+                                    cli,
+                                );
+                            } else if names_without_outer.is_empty() {
+                                variant_deser_code
+                                    .content
+                                    .line(&format!("Ok({}::{})", name, variant.name));
+                            } else {
+                                enum_gen_info.generate_constructor(
+                                    &mut variant_deser_code.content,
+                                    "Ok(",
+                                    ")",
+                                    None,
+                                );
+                            }
+                            variant_deser_code
                         }
-                        variant_deser_code
                     }
                     EnumVariantData::Inlined(record) => make_inline_deser_code(
                         gen_scope,
@@ -6924,6 +6957,7 @@ fn generate_enum(
                 };
                 let cbor_types_str = variant
                     .cbor_types_inner(types, rep)
+                    .expect("Already checked above")
                     .into_iter()
                     .map(cbor_type_code_str)
                     .collect::<Vec<_>>()

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -6899,7 +6899,7 @@ fn generate_enum(
                                 }
                                 _ => RustStructCBORLen::Fixed(1),
                             };
-                            // this will never be 1 line to don't bother with the below cases
+                            // this will never be 1 line so don't bother with the below cases
                             variant_deser_code =
                                 surround_in_len_checks(variant_deser_code, len_info, r, cli);
                             if enum_gen_info.outer_vars == 0 {

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -1310,7 +1310,6 @@ impl RustType {
                 }],
                 ConceptualRustType::Primitive(p) => p.cbor_types(),
                 ConceptualRustType::Rust(ident) => {
-                    eprintln!("{ident:?}");
                     let rust_struct = types.rust_struct(ident).unwrap();
                     if rust_struct.tag.is_some() {
                         vec![CBORType::Tag]

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -5,9 +5,9 @@ use std::collections::BTreeMap;
 
 use crate::comment_ast::{merge_metadata, metadata_from_comments, RuleMetadata};
 use crate::intermediate::{
-    AliasInfo, CDDLIdent, ConceptualRustType, EnumVariant, FixedValue, GenericDef, GenericInstance,
-    IntermediateTypes, ModuleScope, Primitive, Representation, RustField, RustIdent, RustRecord,
-    RustStruct, RustStructType, RustType, VariantIdent,
+    AliasInfo, CBOREncodingOperation, CDDLIdent, ConceptualRustType, EnumVariant, FixedValue,
+    GenericDef, GenericInstance, IntermediateTypes, ModuleScope, Primitive, Representation,
+    RustField, RustIdent, RustRecord, RustStruct, RustStructType, RustType, VariantIdent,
 };
 use crate::utils::{
     append_number_if_duplicate, convert_to_camel_case, convert_to_snake_case,
@@ -1518,7 +1518,12 @@ pub fn parse_group(
                         if let ConceptualRustType::Rust(ident) = &ty.conceptual_type {
                             // we might need to generate it if not used elsewhere
                             types.set_rep_if_plain_group(parent_visitor, ident, rep, cli);
+                            // manual match in case we expand operaitons later
                             types.is_plain_group(ident)
+                                && !ty.encodings.iter().any(|enc| match enc {
+                                    CBOREncodingOperation::Tagged(_) => true,
+                                    CBOREncodingOperation::CBORBytes => true,
+                                })
                         } else {
                             false
                         };

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -68,15 +68,31 @@ non_overlap_basic_embed_mixed = [
   y: text, z: uint
 ]
 
-third = (bytes, uint)
+bytes_uint = (bytes, uint)
 
 non_overlap_basic_embed_mixed_explicit = [
   ; @name first
   x: uint, tag: 0 //
   ; @name second
   y: text, z: uint //
-  ; we don't use name dsl due to: https://github.com/dcSpark/cddl-codegen/issues/230
-  third
+  ; @name third
+  bytes_uint
+]
+
+basic = (uint, text)
+
+basic_arr = [basic]
+
+; not overlap since double array for second
+non_overlap_basic_not_basic = [
+  ; @name group
+  basic //
+  ; @name group_arr
+  basic_arr //
+  ; @name group_tagged
+  #6.11(basic) //
+  ; @name group_bytes
+  bytes .cbor basic
 ]
 
 enums = [

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -40,6 +40,13 @@ non_overlapping_type_choice_all = uint / nint / text / bytes / #6.30("hello worl
 
 non_overlapping_type_choice_some = uint / nint / text
 
+non_overlap_basic_embed =  [
+  ; @name identity
+  tag: 0 //
+  ; @name x
+  tag: 1, hash: bytes .size 32
+]
+
 enums = [
 	c_enum,
 	type_choice,

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -40,11 +40,43 @@ non_overlapping_type_choice_all = uint / nint / text / bytes / #6.30("hello worl
 
 non_overlapping_type_choice_some = uint / nint / text
 
-non_overlap_basic_embed =  [
+overlap_basic_embed =  [
   ; @name identity
   tag: 0 //
   ; @name x
   tag: 1, hash: bytes .size 32
+]
+
+non_overlap_basic_embed = [
+  ; @name first
+  x: uint, tag: 0 //
+  ; @name second
+  y: text, tag: 1
+]
+
+non_overlap_basic_embed_multi_fields = [
+  ; @name first
+  x: uint, z: uint //
+  ; @name second
+  y: text, z: uint
+]
+
+non_overlap_basic_embed_mixed = [
+  ; @name first
+  x: uint, tag: 0 //
+  ; @name second
+  y: text, z: uint
+]
+
+third = (bytes, uint)
+
+non_overlap_basic_embed_mixed_explicit = [
+  ; @name first
+  x: uint, tag: 0 //
+  ; @name second
+  y: text, z: uint //
+  ; we don't use name dsl due to: https://github.com/dcSpark/cddl-codegen/issues/230
+  third
 ]
 
 enums = [

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -275,6 +275,12 @@ mod tests {
         deser_test(&NonOverlappingTypeChoiceSome::N64(10000));
         deser_test(&NonOverlappingTypeChoiceSome::Text("Hello, World!".into()));
     }
+    
+    #[test]
+    fn non_overlap_basic_embed() {
+        deser_test(&NonOverlapBasicEmbed::new_identity());
+        deser_test(&NonOverlapBasicEmbed::new_x(vec![85; 32]).unwrap());
+    }
 
     #[test]
     fn array_opt_fields() {

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -308,6 +308,14 @@ mod tests {
     }
 
     #[test]
+    fn non_overlap_basic_not_basic() {
+        deser_test(&NonOverlapBasicNotBasic::new_group(4, "basic".to_owned()));
+        deser_test(&NonOverlapBasicNotBasic::new_group_arr(Basic::new(4, "".to_owned())));
+        deser_test(&NonOverlapBasicNotBasic::new_group_tagged(0, " T A G G E D ".to_owned()));
+        deser_test(&NonOverlapBasicNotBasic::new_group_bytes(u64::MAX, "bytes .cbor basic".to_owned()));
+    }
+
+    #[test]
     fn array_opt_fields() {
         let mut foo = ArrayOptFields::new(10);
         for e in [None, Some(NonOverlappingTypeChoiceSome::U64(5)), Some(NonOverlappingTypeChoiceSome::N64(4)), Some(NonOverlappingTypeChoiceSome::Text("five".to_owned()))] {

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -277,9 +277,34 @@ mod tests {
     }
     
     #[test]
+    fn overlap_basic_embed() {
+        deser_test(&OverlapBasicEmbed::new_identity());
+        deser_test(&OverlapBasicEmbed::new_x(vec![85; 32]).unwrap());
+    }
+
+    #[test]
     fn non_overlap_basic_embed() {
-        deser_test(&NonOverlapBasicEmbed::new_identity());
-        deser_test(&NonOverlapBasicEmbed::new_x(vec![85; 32]).unwrap());
+        deser_test(&NonOverlapBasicEmbed::new_first(100));
+        deser_test(&NonOverlapBasicEmbed::new_second("cddl".to_owned()));
+    }
+
+    #[test]
+    fn non_overlap_basic_embed_multi_fields() {
+        deser_test(&NonOverlapBasicEmbedMultiFields::new_first(100, 1_000_000));
+        deser_test(&NonOverlapBasicEmbedMultiFields::new_second("cddl".to_owned(), 0));
+    }
+    
+    #[test]
+    fn non_overlap_basic_embed_mixed() {
+        deser_test(&NonOverlapBasicEmbedMixed::new_first(100));
+        deser_test(&NonOverlapBasicEmbedMixed::new_second("cddl".to_owned(), 0));
+    }
+
+    #[test]
+    fn non_overlap_basic_embed_mixed_explicit() {
+        deser_test(&NonOverlapBasicEmbedMixedExplicit::new_first(100));
+        deser_test(&NonOverlapBasicEmbedMixedExplicit::new_second("cddl".to_owned(), 0));
+        deser_test(&NonOverlapBasicEmbedMixedExplicit::new_third(vec![0xBA, 0xAD, 0xF0, 0x0D], 4));
     }
 
     #[test]

--- a/tests/preserve-encodings/input.cddl
+++ b/tests/preserve-encodings/input.cddl
@@ -34,6 +34,13 @@ non_overlapping_type_choice_all = uint / nint / text / bytes / #6.13("hello worl
 
 non_overlapping_type_choice_some = uint / nint / text ; @used_as_key
 
+non_overlap_basic_embed =  [
+  ; @name identity
+  tag: 0 //
+  ; @name x
+  tag: 1, hash: bytes .size 32
+]
+
 c_enum = 3 / 1 / 4
 
 enums = [

--- a/tests/preserve-encodings/input.cddl
+++ b/tests/preserve-encodings/input.cddl
@@ -62,15 +62,31 @@ non_overlap_basic_embed_mixed = [
   y: text, z: uint
 ]
 
-third = (bytes, uint)
+bytes_uint = (bytes, uint)
 
 non_overlap_basic_embed_mixed_explicit = [
   ; @name first
   x: uint, tag: 0 //
   ; @name second
   y: text, z: uint //
-  ; we don't use name dsl due to: https://github.com/dcSpark/cddl-codegen/issues/230
-  third
+  ; @name third
+  bytes_uint
+]
+
+basic = (uint, text)
+
+basic_arr = [basic]
+
+; not overlap since double array for second
+non_overlap_basic_not_basic = [
+  ; @name group
+  basic //
+  ; @name group_arr
+  basic_arr //
+  ; @name group_tagged
+  #6.11(basic) //
+  ; @name group_bytes
+  bytes .cbor basic_arr
 ]
 
 c_enum = 3 / 1 / 4

--- a/tests/preserve-encodings/input.cddl
+++ b/tests/preserve-encodings/input.cddl
@@ -34,11 +34,43 @@ non_overlapping_type_choice_all = uint / nint / text / bytes / #6.13("hello worl
 
 non_overlapping_type_choice_some = uint / nint / text ; @used_as_key
 
-non_overlap_basic_embed =  [
+overlap_basic_embed =  [
   ; @name identity
   tag: 0 //
   ; @name x
   tag: 1, hash: bytes .size 32
+]
+
+non_overlap_basic_embed = [
+  ; @name first
+  x: uint, tag: 0 //
+  ; @name second
+  y: text, tag: 1
+]
+
+non_overlap_basic_embed_multi_fields = [
+  ; @name first
+  x: uint, z: uint //
+  ; @name second
+  y: text, z: uint
+]
+
+non_overlap_basic_embed_mixed = [
+  ; @name first
+  x: uint, tag: 0 //
+  ; @name second
+  y: text, z: uint
+]
+
+third = (bytes, uint)
+
+non_overlap_basic_embed_mixed_explicit = [
+  ; @name first
+  x: uint, tag: 0 //
+  ; @name second
+  y: text, z: uint //
+  ; we don't use name dsl due to: https://github.com/dcSpark/cddl-codegen/issues/230
+  third
 ]
 
 c_enum = 3 / 1 / 4

--- a/tests/preserve-encodings/tests.rs
+++ b/tests/preserve-encodings/tests.rs
@@ -483,6 +483,33 @@ mod tests {
     }
 
     #[test]
+    fn non_overlap_basic_embed() {
+        let def_encodings = vec![Sz::Inline, Sz::One, Sz::Two, Sz::Four, Sz::Eight];
+        let str_32_encodings = vec![
+            StringLenSz::Len(Sz::One),
+            StringLenSz::Indefinite(vec![(16, Sz::Two), (16, Sz::One)]),
+            StringLenSz::Indefinite(vec![(10, Sz::Inline), (0, Sz::Inline), (22, Sz::Four)]),
+        ];
+        for str_enc in &str_32_encodings {
+            for def_enc in &def_encodings {
+                let irregular_bytes_identity = vec![
+                    arr_sz(1, *def_enc),
+                        cbor_int(0, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_bytes_x = vec![
+                    arr_sz(2, *def_enc),
+                        cbor_int(1, *def_enc),
+                        cbor_bytes_sz(vec![170; 32], str_enc.clone()),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_identity = NonOverlapBasicEmbed::from_cbor_bytes(&irregular_bytes_identity).unwrap();
+                assert_eq!(irregular_bytes_identity, irregular_identity.to_cbor_bytes());
+                let irregular_x = NonOverlapBasicEmbed::from_cbor_bytes(&irregular_bytes_x).unwrap();
+                assert_eq!(irregular_bytes_x, irregular_x.to_cbor_bytes());
+            }
+        }
+    }
+
+    #[test]
     fn enums() {
         let def_encodings = vec![Sz::Inline, Sz::One, Sz::Two, Sz::Four, Sz::Eight];
         let enum_values = vec![3, 1, 4];

--- a/tests/preserve-encodings/tests.rs
+++ b/tests/preserve-encodings/tests.rs
@@ -483,7 +483,7 @@ mod tests {
     }
 
     #[test]
-    fn non_overlap_basic_embed() {
+    fn overlap_basic_embed() {
         let def_encodings = vec![Sz::Inline, Sz::One, Sz::Two, Sz::Four, Sz::Eight];
         let str_32_encodings = vec![
             StringLenSz::Len(Sz::One),
@@ -501,10 +501,129 @@ mod tests {
                         cbor_int(1, *def_enc),
                         cbor_bytes_sz(vec![170; 32], str_enc.clone()),
                 ].into_iter().flatten().clone().collect::<Vec<u8>>();
-                let irregular_identity = NonOverlapBasicEmbed::from_cbor_bytes(&irregular_bytes_identity).unwrap();
+                let irregular_identity = OverlapBasicEmbed::from_cbor_bytes(&irregular_bytes_identity).unwrap();
                 assert_eq!(irregular_bytes_identity, irregular_identity.to_cbor_bytes());
-                let irregular_x = NonOverlapBasicEmbed::from_cbor_bytes(&irregular_bytes_x).unwrap();
+                let irregular_x = OverlapBasicEmbed::from_cbor_bytes(&irregular_bytes_x).unwrap();
                 assert_eq!(irregular_bytes_x, irregular_x.to_cbor_bytes());
+            }
+        }
+    }
+
+    #[test]
+    fn non_overlap_basic_embed() {
+        let def_encodings = vec![Sz::Inline, Sz::One, Sz::Two, Sz::Four, Sz::Eight];
+        let str_5_encodings = vec![
+            StringLenSz::Len(Sz::One),
+            StringLenSz::Indefinite(vec![(3, Sz::Two), (2, Sz::One)]),
+            StringLenSz::Indefinite(vec![(0, Sz::Eight), (1, Sz::Inline), (0, Sz::Inline), (4, Sz::Four), (0, Sz::Inline)]),
+        ];
+        for str_enc in &str_5_encodings {
+            for def_enc in &def_encodings {
+                let irregular_bytes_first = vec![
+                    arr_sz(2, *def_enc),
+                        cbor_int(10, *def_enc),
+                        cbor_int(0, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_bytes_second = vec![
+                    arr_sz(2, *def_enc),
+                        cbor_str_sz("world", str_enc.clone()),
+                        cbor_int(1, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_first = NonOverlapBasicEmbed::from_cbor_bytes(&irregular_bytes_first).unwrap();
+                assert_eq!(irregular_bytes_first, irregular_first.to_cbor_bytes());
+                let irregular_second = NonOverlapBasicEmbed::from_cbor_bytes(&irregular_bytes_second).unwrap();
+                assert_eq!(irregular_bytes_second, irregular_second.to_cbor_bytes());
+            }
+        }
+    }
+
+    #[test]
+    fn non_overlap_basic_embed_multi_fields() {
+        let def_encodings = vec![Sz::Inline, Sz::One, Sz::Two, Sz::Four, Sz::Eight];
+        let str_5_encodings = vec![
+            StringLenSz::Len(Sz::One),
+            StringLenSz::Indefinite(vec![(3, Sz::Two), (2, Sz::One)]),
+            StringLenSz::Indefinite(vec![(0, Sz::Eight), (1, Sz::Inline), (0, Sz::Inline), (4, Sz::Four), (0, Sz::Inline)]),
+        ];
+        for str_enc in &str_5_encodings {
+            for def_enc in &def_encodings {
+                let irregular_bytes_first = vec![
+                    arr_sz(2, *def_enc),
+                        cbor_int(10, *def_enc),
+                        cbor_int(11, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_bytes_second = vec![
+                    arr_sz(2, *def_enc),
+                        cbor_str_sz("HELLO", str_enc.clone()),
+                        cbor_int(0, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_first = NonOverlapBasicEmbedMultiFields::from_cbor_bytes(&irregular_bytes_first).unwrap();
+                assert_eq!(irregular_bytes_first, irregular_first.to_cbor_bytes());
+                let irregular_second = NonOverlapBasicEmbedMultiFields::from_cbor_bytes(&irregular_bytes_second).unwrap();
+                assert_eq!(irregular_bytes_second, irregular_second.to_cbor_bytes());
+            }
+        }
+    }
+
+    #[test]
+    fn non_overlap_basic_embed_mixed() {
+        let def_encodings = vec![Sz::Inline, Sz::One, Sz::Two, Sz::Four, Sz::Eight];
+        let str_5_encodings = vec![
+            StringLenSz::Len(Sz::One),
+            StringLenSz::Indefinite(vec![(3, Sz::Two), (2, Sz::One)]),
+            StringLenSz::Indefinite(vec![(0, Sz::Eight), (1, Sz::Inline), (0, Sz::Inline), (4, Sz::Four), (0, Sz::Inline)]),
+        ];
+        for str_enc in &str_5_encodings {
+            for def_enc in &def_encodings {
+                let irregular_bytes_first = vec![
+                    arr_sz(2, *def_enc),
+                        cbor_int(10, *def_enc),
+                        cbor_int(0, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_bytes_second = vec![
+                    arr_sz(2, *def_enc),
+                        cbor_str_sz("world", str_enc.clone()),
+                        cbor_int(1, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_first = NonOverlapBasicEmbedMixed::from_cbor_bytes(&irregular_bytes_first).unwrap();
+                assert_eq!(irregular_bytes_first, irregular_first.to_cbor_bytes());
+                let irregular_second = NonOverlapBasicEmbedMixed::from_cbor_bytes(&irregular_bytes_second).unwrap();
+                assert_eq!(irregular_bytes_second, irregular_second.to_cbor_bytes());
+            }
+        }
+    }
+
+    #[test]
+    fn non_overlap_basic_embed_mixed_explicit() {
+        let def_encodings = vec![Sz::Inline, Sz::One, Sz::Two, Sz::Four, Sz::Eight];
+        let str_5_encodings = vec![
+            StringLenSz::Len(Sz::One),
+            StringLenSz::Indefinite(vec![(3, Sz::Two), (2, Sz::One)]),
+            StringLenSz::Indefinite(vec![(0, Sz::Eight), (1, Sz::Inline), (0, Sz::Inline), (4, Sz::Four), (0, Sz::Inline)]),
+        ];
+        for str_enc in &str_5_encodings {
+            for def_enc in &def_encodings {
+                let irregular_bytes_first = vec![
+                    arr_sz(2, *def_enc),
+                        cbor_int(10, *def_enc),
+                        cbor_int(0, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_bytes_second = vec![
+                    arr_sz(2, *def_enc),
+                        cbor_str_sz("MiXeD", str_enc.clone()),
+                        cbor_int(1, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_bytes_third = vec![
+                    arr_sz(2, *def_enc),
+                        cbor_bytes_sz(vec![0x00, 0x01, 0x02, 0x03, 0x04], str_enc.clone()),
+                        cbor_int(1, *def_enc),
+                ].into_iter().flatten().clone().collect::<Vec<u8>>();
+                let irregular_first = NonOverlapBasicEmbedMixedExplicit::from_cbor_bytes(&irregular_bytes_first).unwrap();
+                assert_eq!(irregular_bytes_first, irregular_first.to_cbor_bytes());
+                let irregular_second = NonOverlapBasicEmbedMixedExplicit::from_cbor_bytes(&irregular_bytes_second).unwrap();
+                assert_eq!(irregular_bytes_second, irregular_second.to_cbor_bytes());
+                let irregular_third = NonOverlapBasicEmbedMixedExplicit::from_cbor_bytes(&irregular_bytes_third).unwrap();
+                assert_eq!(irregular_bytes_third, irregular_third.to_cbor_bytes());
             }
         }
     }


### PR DESCRIPTION
Caused when the inlining would made cddl-codegen think that the types were not overlapping since it was looking at the stored type not the actual starting cbor type (e.g. when it was a fixed value).

This would cause a problem as the type matching introduced in #199 but only in very specific cases with basic groups starting with fixed values.

Various other fixes + more test cases:

Fixes #229
Fixes #230 
Fixes #231 
Fixes #232