### PR TITLE
Better file errors + common import import

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -68,7 +68,7 @@ pub struct Cli {
     /// This is useful for integrating into an exisitng project that is based on
     /// these types.
     #[clap(long, value_parser, value_name = "COMMON_IMPORT_OVERRIDE")]
-    common_import_override: Option<String>,
+    pub common_import_override: Option<String>,
 
     /// An external macro to be called instead of manually emitting functions for
     /// conversions to/from CBOR bytes or JSON.

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -923,11 +923,6 @@ impl GenerationScope {
         for (scope, content) in self.serialize_scopes.iter_mut() {
             content
                 .push_import("super", "*", None)
-                .push_import(
-                    format!("{}::serialization", cli.common_import_rust()),
-                    "*",
-                    None,
-                )
                 .push_import("std::io", "BufRead", None)
                 .push_import("std::io", "Seek", None)
                 .push_import("std::io", "SeekFrom", None)
@@ -935,6 +930,9 @@ impl GenerationScope {
                 .push_import("cbor_event::de", "Deserializer", None)
                 .push_import("cbor_event::se", "Serializer", None)
                 .push_import(format!("{}::error", cli.common_import_rust()), "*", None);
+            if let Some(common_import) = cli.common_import_override.as_ref() {
+                content.push_import(format!("{}::serialization", common_import), "*", None);
+            }
             if cli.preserve_encodings {
                 content.push_import("super::cbor_encodings", "*", None);
             }


### PR DESCRIPTION
* Better error checks/messages for file missing related errors to help debugging as the error was incredibly opaque as to where it originated.

* Imports correctly from the common import override in `serialization.rs` files instead of relying on the `import super::*;` which only works when it's not overrided.