### PR TITLE
Add @doc comment DSL

### DIFF
--- a/docs/docs/comment_dsl.mdx
+++ b/docs/docs/comment_dsl.mdx
@@ -161,6 +161,56 @@ Note that as this is at the field-level it must handle the tag as well as the `u
 
 For more examples see `tests/custom_serialization` (used in the `core` and `core_no_wasm` tests) and `tests/custom_serialization_preserve` (used in the `preserve-encodings` test).
 
+## @doc
+
+This can be placed at field-level, struct-level or variant-level to specify a comment to be placed as a rust doc-comment.
+
+```cddl
+docs = [
+  foo: text, ; @doc this is a field-level comment
+  bar: uint, ; @doc bar is a u64
+] ; @doc struct documentation here
+
+docs_groupchoice = [
+  ; @name first @doc comment-about-first
+  0, uint //
+  ; @doc comments about second @name second
+  text
+] ; @doc type-level comment
+```
+
+Will generate:
+```rust
+/// struct documentation here
+#[derive(Clone, Debug)]
+pub struct Docs {
+    /// this is a field-level comment
+    pub foo: String,
+    /// bar is a u64
+    pub bar: u64,
+}
+
+impl Docs {
+    /// * `foo` - this is a field-level comment
+    /// * `bar` - bar is a u64
+    pub fn new(foo: String, bar: u64) -> Self {
+        Self { foo, bar }
+    }
+}
+
+/// type-level comment
+#[derive(Clone, Debug)]
+pub enum DocsGroupchoice {
+    /// comment-about-first
+    First(u64),
+    /// comments about second
+    Second(String),
+}
+```
+
+Due to the comment dsl parsing this doc comment cannot contain the character `@`.
+
+
 ## _CDDL_CODEGEN_EXTERN_TYPE_
 
 While not as a comment, this allows you to compose in hand-written structs into a cddl spec.

--- a/src/intermediate.rs
+++ b/src/intermediate.rs
@@ -2121,22 +2121,34 @@ pub struct EnumVariant {
     pub name: VariantIdent,
     pub data: EnumVariantData,
     pub serialize_as_embedded_group: bool,
+    pub doc: Option<String>,
 }
 
 impl EnumVariant {
-    pub fn new(name: VariantIdent, rust_type: RustType, serialize_as_embedded_group: bool) -> Self {
+    pub fn new(
+        name: VariantIdent,
+        rust_type: RustType,
+        serialize_as_embedded_group: bool,
+        doc: Option<String>,
+    ) -> Self {
         Self {
             name,
             data: EnumVariantData::RustType(rust_type),
             serialize_as_embedded_group,
+            doc,
         }
     }
 
-    pub fn new_embedded(name: VariantIdent, embedded_record: RustRecord) -> Self {
+    pub fn new_embedded(
+        name: VariantIdent,
+        embedded_record: RustRecord,
+        doc: Option<String>,
+    ) -> Self {
         Self {
             name,
             data: EnumVariantData::Inlined(embedded_record),
             serialize_as_embedded_group: false,
+            doc,
         }
     }
 
@@ -2295,6 +2307,7 @@ pub struct RustStructConfig {
     pub custom_json: bool,
     pub custom_serialize: Option<String>,
     pub custom_deserialize: Option<String>,
+    pub doc: Option<String>,
 }
 
 impl From<Option<&RuleMetadata>> for RustStructConfig {
@@ -2304,6 +2317,7 @@ impl From<Option<&RuleMetadata>> for RustStructConfig {
                 custom_json: rule_metadata.custom_json,
                 custom_serialize: rule_metadata.custom_serialize.clone(),
                 custom_deserialize: rule_metadata.custom_deserialize.clone(),
+                doc: rule_metadata.comment.clone(),
             },
             None => Self::default(),
         }

--- a/tests/core/input.cddl
+++ b/tests/core/input.cddl
@@ -265,3 +265,15 @@ struct_with_custom_serialization = [
   tagged1: #6.9(custom_bytes),
   tagged2: #6.9(uint), ; @custom_serialize write_tagged_uint_str @custom_deserialize read_tagged_uint_str 
 ]
+
+docs = [
+  foo: text, ; @doc this is a field-level comment
+  bar: uint, ; @doc bar is a u64
+] ; @doc struct documentation here
+
+docs_groupchoice = [
+  ; @name first @doc comment-about-first
+  0, uint //
+  ; @doc comments about second @name second
+  text
+] ; @doc type-level comment

--- a/tests/core/tests.rs
+++ b/tests/core/tests.rs
@@ -562,4 +562,19 @@ mod tests {
         let from_bytes = WrapperList::from_cbor_bytes(&bytes).unwrap();
         deser_test(&from_bytes);
     }
+
+    #[test]
+    fn docs() {
+        use std::str::FromStr;
+        // reading the file is the only way to test for comments being generated
+        let lib_rs_with_tests = std::fs::read_to_string(std::path::PathBuf::from_str("src").unwrap().join("lib.rs")).unwrap();
+        // lib.rs includes this very test (and thus those strings we're searching for) so we need to strip that part
+        let lib_rs = &lib_rs_with_tests[..lib_rs_with_tests.find("#[cfg(test)]").unwrap()];
+        assert!(lib_rs.contains("this is a field-level comment"));
+        assert!(lib_rs.contains("bar is a u64"));
+        assert!(lib_rs.contains("struct documentation here"));
+        assert!(lib_rs.contains("comment-about-first"));
+        assert!(lib_rs.contains("comments about second"));
+        assert!(lib_rs.contains("type-level comment"));
+    }
 }


### PR DESCRIPTION
This allows us to specify doc-comments for auto-generated types to avoid users having to manually put in comments afterwards which would be overwritten every re-gen.

There is support for type-level (after the definition), field-level and variant-level (for group/type-choices).